### PR TITLE
Add typed Units columns and UnitMetrics table for per-unit metrics

### DIFF
--- a/scripts/create_sorting_analyzer_nwb.py
+++ b/scripts/create_sorting_analyzer_nwb.py
@@ -52,7 +52,6 @@ sorting_analyzer.compute(
         "spike_amplitudes": {},
         "amplitude_scalings": {},
         "spike_locations": {"method": "grid_convolution"},
-        "quality_metrics": {},
         "template_metrics": {},
         "spiketrain_metrics": {},
     }
@@ -86,6 +85,34 @@ sorting_analyzer.compute(
     user_defined_periods=user_defined_periods,
     minimum_valid_period_duration=0,
 )
+
+# # Option 1: compute metrics with no valid periods
+# sorting_analyzer.compute(
+#     "quality_metrics",
+#     use_valid_periods=False
+# )
+
+# Option 2: compute QC with valid unit periods
+sorting_analyzer.compute(
+    "quality_metrics",
+    use_valid_periods=True
+)
+
+# # Option 3: compute QC with another time support (use 0-3 for all units)
+# qm_user_defined_periods = np.array([], dtype=unit_period_dtype)
+# for unit_index in range(num_units):
+#     # First valid period: 0s–3s
+#     qm_user_defined_periods = np.append(
+#         qm_user_defined_periods,
+#         np.array(
+#             [(0, int(0), int(3.0 * sampling_frequency), unit_index)],
+#             dtype=unit_period_dtype)
+#         )
+# sorting_analyzer.compute(
+#     "quality_metrics",
+#     periods=qm_user_defined_periods
+# )
+
 
 # ---- Step 2: Create the base NWB file with recording and sorting via neuroconv ----
 

--- a/scripts/create_sorting_analyzer_nwb.py
+++ b/scripts/create_sorting_analyzer_nwb.py
@@ -52,6 +52,16 @@ sorting_analyzer.compute(
         "spike_amplitudes": {},
         "amplitude_scalings": {},
         "spike_locations": {"method": "grid_convolution"},
+        # Metrics: SI's quality_metrics, template_metrics, spiketrain_metrics
+        # get redistributed by the writer. Cell-intrinsic metrics
+        # (firing_rate from spiketrain, peak_to_valley and half_width from
+        # template) land as canonical typed columns on nwbfile.units.
+        # Run-dependent metrics (snr, presence_ratio, isi_violations_ratio,
+        # amplitude_cutoff, amplitude_median from quality) land as canonical
+        # typed columns on a MetricsRun instance inside SpikeSortingExtensions.
+        "quality_metrics": {},
+        "template_metrics": {},
+        "spiketrain_metrics": {},
     }
 )
 

--- a/scripts/create_sorting_analyzer_nwb.py
+++ b/scripts/create_sorting_analyzer_nwb.py
@@ -58,7 +58,7 @@ sorting_analyzer.compute(
         # template) land as canonical typed columns on nwbfile.units.
         # Run-dependent metrics (snr, presence_ratio, isi_violations_ratio,
         # amplitude_cutoff, amplitude_median from quality) land as canonical
-        # typed columns on a MetricsRun instance inside SpikeSortingExtensions.
+        # typed columns on a UnitMetrics instance inside SpikeSortingExtensions.
         "quality_metrics": {},
         "template_metrics": {},
         "spiketrain_metrics": {},

--- a/scripts/create_sorting_analyzer_nwb.py
+++ b/scripts/create_sorting_analyzer_nwb.py
@@ -52,13 +52,6 @@ sorting_analyzer.compute(
         "spike_amplitudes": {},
         "amplitude_scalings": {},
         "spike_locations": {"method": "grid_convolution"},
-        # Metrics: SI's quality_metrics, template_metrics, spiketrain_metrics
-        # get redistributed by the writer. Cell-intrinsic metrics
-        # (firing_rate from spiketrain, peak_to_valley and half_width from
-        # template) land as canonical typed columns on nwbfile.units.
-        # Run-dependent metrics (snr, presence_ratio, isi_violations_ratio,
-        # amplitude_cutoff, amplitude_median from quality) land as canonical
-        # typed columns on a UnitMetrics instance inside SpikeSortingExtensions.
         "quality_metrics": {},
         "template_metrics": {},
         "spiketrain_metrics": {},

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -1,3 +1,17 @@
+datasets:
+- neurodata_type_def: FiringRate
+  neurodata_type_inc: VectorData
+  dtype: float
+  doc: Mean firing rate of the unit. When obs_intervals is populated on the 
+    units table, the rate is computed over the union of the unit's valid windows
+    (n_spikes_in_valid_windows / sum(valid_durations)). When obs_intervals is 
+    absent or empty, the rate is computed over the whole recording duration. 
+    Cell-intrinsic property; written as a column on nwbfile.units.
+  attributes:
+  - name: unit
+    dtype: text
+    value: hertz
+    doc: Unit of measurement.
 groups:
 - neurodata_type_def: RandomSpikes
   neurodata_type_inc: NWBDataInterface
@@ -360,19 +374,38 @@ groups:
   - name: waveforms
     target_type: Waveforms
     doc: Link to the Waveforms from which these projections were computed.
-- neurodata_type_def: ValidUnitPeriods
-  neurodata_type_inc: TimeIntervals
-  default_name: valid_unit_periods
-  doc: Valid time periods for each unit, typically computed from false 
-    positive/negative rate estimation or user-defined. Each row represents one 
-    valid period for one unit, with start and stop times inherited from 
-    TimeIntervals. If a unit has multiple disjoint valid periods, each period is
-    stored as a separate row referencing the same unit.
+- neurodata_type_def: MetricsRun
+  neurodata_type_inc: DynamicTable
+  default_name: metrics_run
+  doc: One analysis run's worth of per-unit run-dependent metrics. Each row is 
+    one unit; columns are run-dependent metric values stored as plain VectorData
+    (no canonical types committed in v1). Multiple MetricsRun instances coexist 
+    under SpikeSortingExtensions for multiple curation runs (default run, 
+    valid-window-restricted run, per-period drift QC runs). The instance name 
+    carries the run identity (e.g., 'quality_metrics_default', 
+    'quality_metrics_valid_windows').
   datasets:
   - name: unit
     neurodata_type_inc: DynamicTableRegion
-    doc: Reference to the units table for each row, identifying which unit each 
-      valid period belongs to.
+    doc: Reference to the row in nwbfile.units that each row of this MetricsRun 
+      describes. Makes row-to-unit alignment explicit.
+  - name: valid_intervals
+    neurodata_type_inc: VectorData
+    dtype: float
+    dims:
+    - num_intervals
+    - start|end
+    shape:
+    - null
+    - 2
+    doc: Per-unit observation intervals (start, stop) pairs in seconds, 
+      describing the time windows over which metrics in this run were computed. 
+      If absent, the metrics were computed over the whole recording.
+    quantity: '?'
+  - name: valid_intervals_index
+    neurodata_type_inc: VectorIndex
+    doc: Index into valid_intervals for each row, grouping intervals by row.
+    quantity: '?'
 - neurodata_type_def: SpikeSortingExtensions
   neurodata_type_inc: NWBDataInterface
   default_name: extensions
@@ -418,9 +451,10 @@ groups:
   - neurodata_type_inc: PCAProjectionsConcatenated
     doc: Concatenated-channels PCA projections of spikes (single-ragged).
     quantity: '?'
-  - neurodata_type_inc: ValidUnitPeriods
-    doc: Valid unit periods extension data.
-    quantity: '?'
+  - neurodata_type_inc: MetricsRun
+    doc: Run-dependent per-unit metrics, one instance per analysis run. Multiple
+      instances coexist for different curation runs.
+    quantity: '*'
 - neurodata_type_def: SpikeSortingContainer
   neurodata_type_inc: NWBDataInterface
   default_name: spike_sorting

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -10,6 +10,20 @@ datasets:
     dtype: text
     value: hertz
     doc: Unit of measurement.
+- neurodata_type_def: MetricVectorData
+  neurodata_type_inc: VectorData
+  doc: A VectorData column carrying a run-dependent per-unit metric. May 
+    reference the TimeIntervals (typically ValidUnitPeriods) over which its 
+    values were computed, via the optional `time_support` attribute.
+  attributes:
+  - name: time_support
+    dtype:
+      target_type: ValidUnitPeriods
+      reftype: object
+    doc: Object reference to the TimeIntervals (typically ValidUnitPeriods) over
+      which this column's metric values were computed. Absent when no time 
+      restriction was applied.
+    required: false
 groups:
 - neurodata_type_def: RandomSpikes
   neurodata_type_inc: NWBDataInterface
@@ -372,38 +386,6 @@ groups:
   - name: waveforms
     target_type: Waveforms
     doc: Link to the Waveforms from which these projections were computed.
-- neurodata_type_def: UnitMetrics
-  neurodata_type_inc: DynamicTable
-  default_name: unit_metrics
-  doc: Per-unit metric values from one analysis run. Each row is one unit; 
-    columns are metric values. The required `unit` DynamicTableRegion references
-    the corresponding row in nwbfile.units. Multiple instances coexist under 
-    SpikeSortingExtensions for different analysis runs.
-  datasets:
-  - name: unit
-    neurodata_type_inc: DynamicTableRegion
-    doc: Reference to the row in nwbfile.units that each row of this UnitMetrics
-      describes.
-  - name: time_support
-    neurodata_type_inc: VectorData
-    dtype: float
-    dims:
-    - num_intervals
-    - start_end
-    shape:
-    - null
-    - 2
-    doc: Per-unit time intervals (start, stop) in seconds over which this row's 
-      metric values were computed. Each row's metric values reflect only events 
-      that fell within these per-unit windows. Ragged by row via 
-      time_support_index. Distinct from `Units.obs_intervals` (NWB-core), which 
-      constrains the validity of `spike_times` on the Units table; this column 
-      records the analysis-time windows used as input to this row's computation.
-    quantity: '?'
-  - name: time_support_index
-    neurodata_type_inc: VectorIndex
-    doc: Index column for the ragged time_support column.
-    quantity: '?'
 - neurodata_type_def: ValidUnitPeriods
   neurodata_type_inc: TimeIntervals
   default_name: valid_unit_periods
@@ -417,6 +399,20 @@ groups:
     neurodata_type_inc: DynamicTableRegion
     doc: Reference to the units table for each row, identifying which unit each 
       valid period belongs to.
+- neurodata_type_def: UnitMetrics
+  neurodata_type_inc: DynamicTable
+  default_name: unit_metrics
+  doc: Per-unit metric values from one analysis run. Each row is one unit; 
+    columns are metric values, typed as MetricVectorData so they can carry an 
+    optional reference to the TimeIntervals over which they were computed. The 
+    required `unit` DynamicTableRegion references the corresponding row in 
+    nwbfile.units. Multiple instances coexist under SpikeSortingExtensions for 
+    different analysis runs.
+  datasets:
+  - name: unit
+    neurodata_type_inc: DynamicTableRegion
+    doc: Reference to the row in nwbfile.units that each row of this UnitMetrics
+      describes.
 - neurodata_type_def: SpikeSortingExtensions
   neurodata_type_inc: NWBDataInterface
   default_name: extensions

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -384,6 +384,22 @@ groups:
     neurodata_type_inc: DynamicTableRegion
     doc: Reference to the row in nwbfile.units that each row of this UnitMetrics
       describes.
+  - name: obs_intervals
+    neurodata_type_inc: VectorData
+    dtype: float
+    dims:
+    - num_intervals
+    - start_end
+    shape:
+    - null
+    - 2
+    doc: Per-unit observation intervals (start, stop) in seconds over which this
+      row's metric values were computed. Ragged by row via obs_intervals_index.
+    quantity: '?'
+  - name: obs_intervals_index
+    neurodata_type_inc: VectorIndex
+    doc: Index column for the ragged obs_intervals column.
+    quantity: '?'
 - neurodata_type_def: ValidUnitPeriods
   neurodata_type_inc: TimeIntervals
   default_name: valid_unit_periods

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -399,9 +399,9 @@ groups:
     neurodata_type_inc: DynamicTableRegion
     doc: Reference to the units table for each row, identifying which unit each 
       valid period belongs to.
-- neurodata_type_def: UnitMetrics
+- neurodata_type_def: UnitsMetrics
   neurodata_type_inc: DynamicTable
-  default_name: unit_metrics
+  default_name: units_metrics
   doc: Per-unit metric values from one analysis run. Each row is one unit; 
     columns are metric values, typed as MetricVectorData so they can carry an 
     optional reference to the TimeIntervals over which they were computed. The 
@@ -411,8 +411,8 @@ groups:
   datasets:
   - name: unit
     neurodata_type_inc: DynamicTableRegion
-    doc: Reference to the row in nwbfile.units that each row of this UnitMetrics
-      describes.
+    doc: Reference to the row in nwbfile.units that each row of this 
+      UnitsMetrics describes.
 - neurodata_type_def: SpikeSortingExtensions
   neurodata_type_inc: NWBDataInterface
   default_name: extensions
@@ -458,7 +458,7 @@ groups:
   - neurodata_type_inc: PCAProjectionsConcatenated
     doc: Concatenated-channels PCA projections of spikes (single-ragged).
     quantity: '?'
-  - neurodata_type_inc: UnitMetrics
+  - neurodata_type_inc: UnitsMetrics
     doc: Per-unit metrics from one analysis run. Multiple instances coexist for 
       different runs (different parameter sets).
     quantity: '*'

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -384,7 +384,7 @@ groups:
     neurodata_type_inc: DynamicTableRegion
     doc: Reference to the row in nwbfile.units that each row of this UnitMetrics
       describes.
-  - name: obs_intervals
+  - name: computation_intervals
     neurodata_type_inc: VectorData
     dtype: float
     dims:
@@ -393,12 +393,17 @@ groups:
     shape:
     - null
     - 2
-    doc: Per-unit observation intervals (start, stop) in seconds over which this
-      row's metric values were computed. Ragged by row via obs_intervals_index.
+    doc: Per-unit time intervals (start, stop) in seconds over which this row's 
+      metric values were computed. Captures the `periods` argument passed to the
+      SpikeInterface metric extension at compute time. Ragged by row via 
+      computation_intervals_index. Distinct from `Units.obs_intervals` 
+      (NWB-core), which constrains the validity of `spike_times` on the Units 
+      table; this column records the analysis-time windows used as input to this
+      row's computation.
     quantity: '?'
-  - name: obs_intervals_index
+  - name: computation_intervals_index
     neurodata_type_inc: VectorIndex
-    doc: Index column for the ragged obs_intervals column.
+    doc: Index column for the ragged computation_intervals column.
     quantity: '?'
 - neurodata_type_def: ValidUnitPeriods
   neurodata_type_inc: TimeIntervals

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -374,12 +374,12 @@ groups:
   - name: waveforms
     target_type: Waveforms
     doc: Link to the Waveforms from which these projections were computed.
-- neurodata_type_def: MetricsRun
+- neurodata_type_def: UnitMetrics
   neurodata_type_inc: DynamicTable
-  default_name: metrics_run
+  default_name: unit_metrics
   doc: One analysis run's worth of per-unit run-dependent metrics. Each row is 
     one unit; columns are run-dependent metric values stored as plain VectorData
-    (no canonical types committed in v1). Multiple MetricsRun instances coexist 
+    (no canonical types committed in v1). Multiple UnitMetrics instances coexist
     under SpikeSortingExtensions for multiple curation runs (default run, 
     valid-window-restricted run, per-period drift QC runs). The instance name 
     carries the run identity (e.g., 'quality_metrics_default', 
@@ -387,7 +387,7 @@ groups:
   datasets:
   - name: unit
     neurodata_type_inc: DynamicTableRegion
-    doc: Reference to the row in nwbfile.units that each row of this MetricsRun 
+    doc: Reference to the row in nwbfile.units that each row of this UnitMetrics
       describes. Makes row-to-unit alignment explicit.
   - name: valid_intervals
     neurodata_type_inc: VectorData
@@ -451,7 +451,7 @@ groups:
   - neurodata_type_inc: PCAProjectionsConcatenated
     doc: Concatenated-channels PCA projections of spikes (single-ragged).
     quantity: '?'
-  - neurodata_type_inc: MetricsRun
+  - neurodata_type_inc: UnitMetrics
     doc: Run-dependent per-unit metrics, one instance per analysis run. Multiple
       instances coexist for different curation runs.
     quantity: '*'

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -377,35 +377,28 @@ groups:
 - neurodata_type_def: UnitMetrics
   neurodata_type_inc: DynamicTable
   default_name: unit_metrics
-  doc: One analysis run's worth of per-unit run-dependent metrics. Each row is 
-    one unit; columns are run-dependent metric values stored as plain VectorData
-    (no canonical types committed in v1). Multiple UnitMetrics instances coexist
-    under SpikeSortingExtensions for multiple curation runs (default run, 
-    valid-window-restricted run, per-period drift QC runs). The instance name 
-    carries the run identity (e.g., 'quality_metrics_default', 
-    'quality_metrics_valid_windows').
+  doc: Per-unit metric values from one analysis run. Each row is one unit; 
+    columns are metric values. The required `unit` DynamicTableRegion references
+    the corresponding row in nwbfile.units. Multiple instances coexist under 
+    SpikeSortingExtensions for different analysis runs.
   datasets:
   - name: unit
     neurodata_type_inc: DynamicTableRegion
     doc: Reference to the row in nwbfile.units that each row of this UnitMetrics
-      describes. Makes row-to-unit alignment explicit.
-  - name: valid_intervals
-    neurodata_type_inc: VectorData
-    dtype: float
-    dims:
-    - num_intervals
-    - start|end
-    shape:
-    - null
-    - 2
-    doc: Per-unit observation intervals (start, stop) pairs in seconds, 
-      describing the time windows over which metrics in this run were computed. 
-      If absent, the metrics were computed over the whole recording.
-    quantity: '?'
-  - name: valid_intervals_index
-    neurodata_type_inc: VectorIndex
-    doc: Index into valid_intervals for each row, grouping intervals by row.
-    quantity: '?'
+      describes.
+- neurodata_type_def: ValidUnitPeriods
+  neurodata_type_inc: TimeIntervals
+  default_name: valid_unit_periods
+  doc: Valid time periods for each unit, typically computed from false 
+    positive/negative rate estimation or user-defined. Each row represents one 
+    valid period for one unit, with start and stop times inherited from 
+    TimeIntervals. If a unit has multiple disjoint valid periods, each period is
+    stored as a separate row referencing the same unit.
+  datasets:
+  - name: unit
+    neurodata_type_inc: DynamicTableRegion
+    doc: Reference to the units table for each row, identifying which unit each 
+      valid period belongs to.
 - neurodata_type_def: SpikeSortingExtensions
   neurodata_type_inc: NWBDataInterface
   default_name: extensions
@@ -452,9 +445,12 @@ groups:
     doc: Concatenated-channels PCA projections of spikes (single-ragged).
     quantity: '?'
   - neurodata_type_inc: UnitMetrics
-    doc: Run-dependent per-unit metrics, one instance per analysis run. Multiple
-      instances coexist for different curation runs.
+    doc: Per-unit metrics from one analysis run. Multiple instances coexist for 
+      different runs (different parameter sets).
     quantity: '*'
+  - neurodata_type_inc: ValidUnitPeriods
+    doc: Valid unit periods extension data.
+    quantity: '?'
 - neurodata_type_def: SpikeSortingContainer
   neurodata_type_inc: NWBDataInterface
   default_name: spike_sorting

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -2,11 +2,9 @@ datasets:
 - neurodata_type_def: FiringRate
   neurodata_type_inc: VectorData
   dtype: float
-  doc: Mean firing rate of the unit. When obs_intervals is populated on the 
-    units table, the rate is computed over the union of the unit's valid windows
-    (n_spikes_in_valid_windows / sum(valid_durations)). When obs_intervals is 
-    absent or empty, the rate is computed over the whole recording duration. 
-    Cell-intrinsic property; written as a column on nwbfile.units.
+  doc: Mean firing rate of the unit, computed as the number of spikes divided by
+    the recording duration. Cell-intrinsic property; written as a column on 
+    nwbfile.units.
   attributes:
   - name: unit
     dtype: text

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -384,7 +384,7 @@ groups:
     neurodata_type_inc: DynamicTableRegion
     doc: Reference to the row in nwbfile.units that each row of this UnitMetrics
       describes.
-  - name: computation_intervals
+  - name: time_support
     neurodata_type_inc: VectorData
     dtype: float
     dims:
@@ -394,16 +394,15 @@ groups:
     - null
     - 2
     doc: Per-unit time intervals (start, stop) in seconds over which this row's 
-      metric values were computed. Captures the `periods` argument passed to the
-      SpikeInterface metric extension at compute time. Ragged by row via 
-      computation_intervals_index. Distinct from `Units.obs_intervals` 
-      (NWB-core), which constrains the validity of `spike_times` on the Units 
-      table; this column records the analysis-time windows used as input to this
-      row's computation.
+      metric values were computed. Each row's metric values reflect only events 
+      that fell within these per-unit windows. Ragged by row via 
+      time_support_index. Distinct from `Units.obs_intervals` (NWB-core), which 
+      constrains the validity of `spike_times` on the Units table; this column 
+      records the analysis-time windows used as input to this row's computation.
     quantity: '?'
-  - name: computation_intervals_index
+  - name: time_support_index
     neurodata_type_inc: VectorIndex
-    doc: Index column for the ragged computation_intervals column.
+    doc: Index column for the ragged time_support column.
     quantity: '?'
 - neurodata_type_def: ValidUnitPeriods
   neurodata_type_inc: TimeIntervals

--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -10,19 +10,22 @@ datasets:
     dtype: text
     value: hertz
     doc: Unit of measurement.
-- neurodata_type_def: MetricVectorData
+- neurodata_type_def: UnitVectorData
   neurodata_type_inc: VectorData
-  doc: A VectorData column carrying a run-dependent per-unit metric. May 
-    reference the TimeIntervals (typically ValidUnitPeriods) over which its 
-    values were computed, via the optional `time_support` attribute.
+  doc: A VectorData column carrying per-unit values. May reference the 
+    TimeIntervals over which the values were computed, via the optional 
+    `time_support` attribute. Used as the column type for run-dependent metric 
+    values on UnitsMetrics; also suitable for cell-intrinsic typed columns on 
+    the Units table.
   attributes:
   - name: time_support
     dtype:
-      target_type: ValidUnitPeriods
+      target_type: TimeIntervals
       reftype: object
-    doc: Object reference to the TimeIntervals (typically ValidUnitPeriods) over
-      which this column's metric values were computed. Absent when no time 
-      restriction was applied.
+    doc: Object reference to the TimeIntervals (plain or a ValidUnitPeriods 
+      subclass) over which this column's values were computed. Absent when no 
+      time restriction was applied (e.g., for metrics whose computation does not
+      respect per-unit periods).
     required: false
 groups:
 - neurodata_type_def: RandomSpikes
@@ -403,7 +406,7 @@ groups:
   neurodata_type_inc: DynamicTable
   default_name: units_metrics
   doc: Per-unit metric values from one analysis run. Each row is one unit; 
-    columns are metric values, typed as MetricVectorData so they can carry an 
+    columns are metric values, typed as UnitVectorData so they can carry an 
     optional reference to the TimeIntervals over which they were computed. The 
     required `unit` DynamicTableRegion references the corresponding row in 
     nwbfile.units. Multiple instances coexist under SpikeSortingExtensions for 
@@ -463,8 +466,16 @@ groups:
       different runs (different parameter sets).
     quantity: '*'
   - neurodata_type_inc: ValidUnitPeriods
-    doc: Valid unit periods extension data.
-    quantity: '?'
+    doc: Valid time periods per unit from spike sorting quality estimation. 
+      Multiple instances may coexist when different analysis parameter sets 
+      produce different validity tables.
+    quantity: '*'
+  - neurodata_type_inc: TimeIntervals
+    doc: Plain NWB-core TimeIntervals tables, used for metric time-support 
+      windows when those windows did not come from a validity computation (e.g.,
+      user-defined periods passed directly to quality_metrics). Each row has 
+      start_time, stop_time, and a `unit` DynamicTableRegion column.
+    quantity: '*'
 - neurodata_type_def: SpikeSortingContainer
   neurodata_type_inc: NWBDataInterface
   default_name: spike_sorting

--- a/spec/ndx-spikesorting.namespace.yaml
+++ b/spec/ndx-spikesorting.namespace.yaml
@@ -8,5 +8,11 @@ namespaces:
   name: ndx-spikesorting
   schema:
   - namespace: core
+  - namespace: hdmf-common
+    neurodata_types:
+    - DynamicTable
+    - VectorData
+    - VectorIndex
+    - DynamicTableRegion
   - source: ndx-spikesorting.extensions.yaml
   version: 0.1.0

--- a/src/pynwb/ndx_spikesorting/__init__.py
+++ b/src/pynwb/ndx_spikesorting/__init__.py
@@ -34,6 +34,8 @@ FiringRate = get_class("FiringRate", "ndx-spikesorting")
 # Multi-instance container for run-dependent metrics
 UnitMetrics = get_class("UnitMetrics", "ndx-spikesorting")
 
+ValidUnitPeriods = get_class("ValidUnitPeriods", "ndx-spikesorting")
+
 SpikeSortingExtensions = get_class("SpikeSortingExtensions", "ndx-spikesorting")
 SpikeSortingContainer = get_class("SpikeSortingContainer", "ndx-spikesorting")
 
@@ -55,6 +57,7 @@ __all__ = [
     "PCAProjectionsConcatenated",
     "FiringRate",
     "UnitMetrics",
+    "ValidUnitPeriods",
     "SpikeSortingExtensions",
     "SpikeSortingContainer",
     "templates_to_dense",

--- a/src/pynwb/ndx_spikesorting/__init__.py
+++ b/src/pynwb/ndx_spikesorting/__init__.py
@@ -32,13 +32,13 @@ PCAProjectionsConcatenated = get_class("PCAProjectionsConcatenated", "ndx-spikes
 FiringRate = get_class("FiringRate", "ndx-spikesorting")
 
 # Typed VectorData carrying an optional time_support reference attribute
-MetricVectorData = get_class("MetricVectorData", "ndx-spikesorting")
+UnitVectorData = get_class("UnitVectorData", "ndx-spikesorting")
 
 ValidUnitPeriods = get_class("ValidUnitPeriods", "ndx-spikesorting")
 
 # Multi-instance container for run-dependent metrics. We override add_column on
 # the auto-generated class so that columns added by users default to
-# MetricVectorData (carrying the optional time_support reference) without
+# UnitVectorData (carrying the optional time_support reference) without
 # having to pass col_cls explicitly. The `unit` DynamicTableRegion is left
 # alone. The subclass is re-registered as the canonical class for the
 # neurodata_type so it's used on read as well as write.
@@ -50,14 +50,14 @@ class UnitsMetrics(_AutoUnitsMetrics):
     """UnitsMetrics with a metric-aware ``add_column`` default.
 
     When ``col_cls`` is not provided and the column being added is not the
-    ``unit`` DynamicTableRegion, columns default to ``MetricVectorData`` so
+    ``unit`` DynamicTableRegion, columns default to ``UnitVectorData`` so
     they can carry the optional ``time_support`` reference. Pass
     ``col_cls=VectorData`` explicitly to opt out for a particular column.
     """
 
     def add_column(self, **kwargs):
         if kwargs.get("col_cls") is None and kwargs.get("name") != "unit":
-            kwargs["col_cls"] = MetricVectorData
+            kwargs["col_cls"] = UnitVectorData
         return super().add_column(**kwargs)
 
 SpikeSortingExtensions = get_class("SpikeSortingExtensions", "ndx-spikesorting")
@@ -80,7 +80,7 @@ __all__ = [
     "PCAProjectionsByChannel",
     "PCAProjectionsConcatenated",
     "FiringRate",
-    "MetricVectorData",
+    "UnitVectorData",
     "UnitsMetrics",
     "ValidUnitPeriods",
     "SpikeSortingExtensions",

--- a/src/pynwb/ndx_spikesorting/__init__.py
+++ b/src/pynwb/ndx_spikesorting/__init__.py
@@ -34,10 +34,31 @@ FiringRate = get_class("FiringRate", "ndx-spikesorting")
 # Typed VectorData carrying an optional time_support reference attribute
 MetricVectorData = get_class("MetricVectorData", "ndx-spikesorting")
 
-# Multi-instance container for run-dependent metrics
-UnitMetrics = get_class("UnitMetrics", "ndx-spikesorting")
-
 ValidUnitPeriods = get_class("ValidUnitPeriods", "ndx-spikesorting")
+
+# Multi-instance container for run-dependent metrics. We override add_column on
+# the auto-generated class so that columns added by users default to
+# MetricVectorData (carrying the optional time_support reference) without
+# having to pass col_cls explicitly. The `unit` DynamicTableRegion is left
+# alone. The subclass is re-registered as the canonical class for the
+# neurodata_type so it's used on read as well as write.
+_AutoUnitsMetrics = get_class("UnitsMetrics", "ndx-spikesorting")
+
+
+@register_class("UnitsMetrics", "ndx-spikesorting")
+class UnitsMetrics(_AutoUnitsMetrics):
+    """UnitsMetrics with a metric-aware ``add_column`` default.
+
+    When ``col_cls`` is not provided and the column being added is not the
+    ``unit`` DynamicTableRegion, columns default to ``MetricVectorData`` so
+    they can carry the optional ``time_support`` reference. Pass
+    ``col_cls=VectorData`` explicitly to opt out for a particular column.
+    """
+
+    def add_column(self, **kwargs):
+        if kwargs.get("col_cls") is None and kwargs.get("name") != "unit":
+            kwargs["col_cls"] = MetricVectorData
+        return super().add_column(**kwargs)
 
 SpikeSortingExtensions = get_class("SpikeSortingExtensions", "ndx-spikesorting")
 SpikeSortingContainer = get_class("SpikeSortingContainer", "ndx-spikesorting")
@@ -60,7 +81,7 @@ __all__ = [
     "PCAProjectionsConcatenated",
     "FiringRate",
     "MetricVectorData",
-    "UnitMetrics",
+    "UnitsMetrics",
     "ValidUnitPeriods",
     "SpikeSortingExtensions",
     "SpikeSortingContainer",

--- a/src/pynwb/ndx_spikesorting/__init__.py
+++ b/src/pynwb/ndx_spikesorting/__init__.py
@@ -31,6 +31,9 @@ PCAProjectionsConcatenated = get_class("PCAProjectionsConcatenated", "ndx-spikes
 # Canonical typed VectorData column for nwbfile.units
 FiringRate = get_class("FiringRate", "ndx-spikesorting")
 
+# Typed VectorData carrying an optional time_support reference attribute
+MetricVectorData = get_class("MetricVectorData", "ndx-spikesorting")
+
 # Multi-instance container for run-dependent metrics
 UnitMetrics = get_class("UnitMetrics", "ndx-spikesorting")
 
@@ -56,6 +59,7 @@ __all__ = [
     "PCAProjectionsByChannel",
     "PCAProjectionsConcatenated",
     "FiringRate",
+    "MetricVectorData",
     "UnitMetrics",
     "ValidUnitPeriods",
     "SpikeSortingExtensions",

--- a/src/pynwb/ndx_spikesorting/__init__.py
+++ b/src/pynwb/ndx_spikesorting/__init__.py
@@ -28,20 +28,11 @@ AmplitudeScalings = get_class("AmplitudeScalings", "ndx-spikesorting")
 PCAProjectionsByChannel = get_class("PCAProjectionsByChannel", "ndx-spikesorting")
 PCAProjectionsConcatenated = get_class("PCAProjectionsConcatenated", "ndx-spikesorting")
 
-# Canonical typed VectorData columns (cell-intrinsic, live on nwbfile.units)
-# v1 commits one illustrative column. The other candidates (PeakToTrough,
-# TroughHalfWidth, AmplitudeMedian) and the run-dependent set defer to
-# follow-up PRs, one per metric, where their cross-pipeline variability
-# can be discussed without coupling to the structural change.
+# Canonical typed VectorData column for nwbfile.units
 FiringRate = get_class("FiringRate", "ndx-spikesorting")
 
-# No canonical typed VectorData columns are committed for the run-dependent
-# side in v1. Run-dependent metrics flow into MetricsRun instances as plain
-# VectorData columns. See the vault note canonical_unit_columns.md for the
-# cross-pipeline variability analysis that led to deferring these.
-
 # Multi-instance container for run-dependent metrics
-MetricsRun = get_class("MetricsRun", "ndx-spikesorting")
+UnitMetrics = get_class("UnitMetrics", "ndx-spikesorting")
 
 SpikeSortingExtensions = get_class("SpikeSortingExtensions", "ndx-spikesorting")
 SpikeSortingContainer = get_class("SpikeSortingContainer", "ndx-spikesorting")
@@ -63,7 +54,7 @@ __all__ = [
     "PCAProjectionsByChannel",
     "PCAProjectionsConcatenated",
     "FiringRate",
-    "MetricsRun",
+    "UnitMetrics",
     "SpikeSortingExtensions",
     "SpikeSortingContainer",
     "templates_to_dense",

--- a/src/pynwb/ndx_spikesorting/__init__.py
+++ b/src/pynwb/ndx_spikesorting/__init__.py
@@ -27,7 +27,21 @@ SpikeLocations = get_class("SpikeLocations", "ndx-spikesorting")
 AmplitudeScalings = get_class("AmplitudeScalings", "ndx-spikesorting")
 PCAProjectionsByChannel = get_class("PCAProjectionsByChannel", "ndx-spikesorting")
 PCAProjectionsConcatenated = get_class("PCAProjectionsConcatenated", "ndx-spikesorting")
-ValidUnitPeriods = get_class("ValidUnitPeriods", "ndx-spikesorting")
+
+# Canonical typed VectorData columns (cell-intrinsic, live on nwbfile.units)
+# v1 commits one illustrative column. The other candidates (PeakToTrough,
+# TroughHalfWidth, AmplitudeMedian) and the run-dependent set defer to
+# follow-up PRs, one per metric, where their cross-pipeline variability
+# can be discussed without coupling to the structural change.
+FiringRate = get_class("FiringRate", "ndx-spikesorting")
+
+# No canonical typed VectorData columns are committed for the run-dependent
+# side in v1. Run-dependent metrics flow into MetricsRun instances as plain
+# VectorData columns. See the vault note canonical_unit_columns.md for the
+# cross-pipeline variability analysis that led to deferring these.
+
+# Multi-instance container for run-dependent metrics
+MetricsRun = get_class("MetricsRun", "ndx-spikesorting")
 
 SpikeSortingExtensions = get_class("SpikeSortingExtensions", "ndx-spikesorting")
 SpikeSortingContainer = get_class("SpikeSortingContainer", "ndx-spikesorting")
@@ -48,7 +62,8 @@ __all__ = [
     "AmplitudeScalings",
     "PCAProjectionsByChannel",
     "PCAProjectionsConcatenated",
-    "ValidUnitPeriods",
+    "FiringRate",
+    "MetricsRun",
     "SpikeSortingExtensions",
     "SpikeSortingContainer",
     "templates_to_dense",

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -27,7 +27,7 @@ from ndx_spikesorting import (
     PCAProjectionsByChannel,
     PCAProjectionsConcatenated,
     FiringRate,
-    MetricsRun,
+    UnitMetrics,
     SpikeSortingExtensions,
     SpikeSortingContainer,
 )
@@ -43,23 +43,16 @@ from ndx_spikesorting import (
 # This mapping is the single point of SI knowledge in the loader; the spec
 # itself stays tool-agnostic.
 
+# Mapping from canonical typed column class -> (si_metric_name, si_extension_name).
+# The writer routes SI's DataFrame columns to typed columns when the class is
+# registered here; otherwise the column is written as plain VectorData.
 CELL_INTRINSIC_COLUMNS = {
-    # column class -> (si_metric_name, si_extension_name)
-    # v1 canonizes one column to illustrate the pattern. Other candidates
-    # (peak_to_trough_duration, trough_half_width, amplitude_median) round-trip
-    # as plain VectorData columns on nwbfile.units until they get their own
-    # follow-up PR with cross-pipeline-variability discussion.
     FiringRate: ("firing_rate", "spiketrain_metrics"),
 }
 
-# Run-dependent metrics flow into MetricsRun instances as plain VectorData
-# columns. No typed-column classes are committed in v1 because each candidate
-# (Snr, PresenceRatio, IsiViolationsRatio, AmplitudeCutoff) requires multiple
-# attributes to capture cross-pipeline variability and the field has not
-# converged on canonical conventions. The writer below pulls SI's
-# quality_metrics DataFrame columns and writes them as untyped float columns
-# on the MetricsRun instance, preserving column names so the SI extension can
-# be reconstructed on read.
+# No typed column classes are registered yet for the run-dependent side;
+# run-dependent metrics flow as plain VectorData columns onto UnitMetrics
+# instances. The registry is kept for forward compatibility.
 RUN_DEPENDENT_COLUMNS: dict = {}
 
 
@@ -375,11 +368,11 @@ def _add_cell_intrinsic_columns_to_units(
         )
 
 
-def _convert_metrics_run(
+def _convert_unit_metrics(
     sorting_analyzer: "SortingAnalyzer",
     nwbfile: NWBFile,
-) -> MetricsRun | None:
-    """Build a MetricsRun instance from SI's ``quality_metrics`` extension.
+) -> UnitMetrics | None:
+    """Build a UnitMetrics instance from SI's ``quality_metrics`` extension.
 
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
@@ -418,7 +411,7 @@ def _convert_metrics_run(
         typed_column_names.add(si_name)
 
     # The remaining quality_metrics DataFrame columns become plain VectorData
-    # on the MetricsRun instance. Column names are preserved so the loader can
+    # on the UnitMetrics instance. Column names are preserved so the loader can
     # reconstruct SI's quality_metrics extension on read.
     for col_name in df.columns:
         if col_name in typed_column_names:
@@ -434,7 +427,7 @@ def _convert_metrics_run(
         )
 
     # If valid_unit_periods is computed, store the per-unit windows as
-    # valid_intervals on this MetricsRun instance. valid_intervals is ragged by row
+    # valid_intervals on this UnitMetrics instance. valid_intervals is ragged by row
     # (one row per unit), each cell holds the list of (start, stop) windows
     # used to restrict that unit's metric computation.
     vup_ext = sorting_analyzer.get_extension("valid_unit_periods")
@@ -475,7 +468,7 @@ def _convert_metrics_run(
         columns.append(valid_intervals_vd)
         columns.append(valid_intervals_index)
 
-    return MetricsRun(
+    return UnitMetrics(
         name="quality_metrics",
         description="Run-dependent per-unit metrics from one analysis run.",
         columns=columns,
@@ -679,12 +672,12 @@ def _convert_all_extensions(sorting_analyzer, nwbfile):  # noqa: C901
             raise ValueError("PCA projections require waveforms to be computed.")
         converted.update(_convert_pca(sorting_analyzer, nwbfile, converted["waveforms"]))
 
-    # Run-dependent metrics flow into a MetricsRun instance (or several, as
+    # Run-dependent metrics flow into a UnitMetrics instance (or several, as
     # support for multiple curation runs is added). For v1 there is one
-    # MetricsRun per file, sourced from SI's quality_metrics extension.
-    metrics_run = _convert_metrics_run(sorting_analyzer, nwbfile)
-    if metrics_run is not None:
-        converted["__metrics_run__"] = metrics_run
+    # UnitMetrics per file, sourced from SI's quality_metrics extension.
+    unit_metrics = _convert_unit_metrics(sorting_analyzer, nwbfile)
+    if unit_metrics is not None:
+        converted["__unit_metrics__"] = unit_metrics
 
     return converted
 
@@ -702,8 +695,8 @@ def _build_extensions(sorting_analyzer, nwbfile):
     converted = _convert_all_extensions(sorting_analyzer, nwbfile)
     extensions = SpikeSortingExtensions(name="extensions")
     for attr, obj in converted.items():
-        if attr == "__metrics_run__":
-            extensions.add_metrics_runs(obj)
+        if attr == "__unit_metrics__":
+            extensions.add_unit_metrics(obj)
         else:
             setattr(extensions, attr, obj)
     return extensions
@@ -912,7 +905,7 @@ def read_sorting_analyzer_from_nwb(
             _load_amplitude_scalings(extensions, sorting_analyzer)
             _load_spike_locations(extensions, sorting_analyzer)
             _load_pca_projections(extensions, sorting_analyzer)
-            _load_metrics_runs(extensions, sorting_analyzer)
+            _load_unit_metrics(extensions, sorting_analyzer)
 
         # Cell-intrinsic metrics live on nwbfile.units as typed columns; read
         # them by column type so the SI extension binding survives even if a
@@ -1212,8 +1205,8 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
     typed VectorData classes, and populates the corresponding SI extension
     DataFrames. Routes by column class via ``CELL_INTRINSIC_COLUMNS``.
 
-    When a target SI extension was already populated by ``_load_metrics_runs``
-    (e.g. quality_metrics receives both ``Snr`` from a MetricsRun and
+    When a target SI extension was already populated by ``_load_unit_metrics``
+    (e.g. quality_metrics receives both ``Snr`` from a UnitMetrics and
     ``AmplitudeMedian`` from a Units column), this function merges into the
     existing DataFrame rather than overwriting it.
     """
@@ -1232,7 +1225,7 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
         existing = sorting_analyzer.extensions.get(si_ext_name)
         if existing is not None:
             # Merge into existing DataFrame; preserve any params/metric_names set
-            # by the prior loader (typically _load_metrics_runs for quality_metrics).
+            # by the prior loader (typically _load_unit_metrics for quality_metrics).
             existing_df = existing.data.get("metrics")
             if existing_df is not None:
                 for col_name, values in columns_dict.items():
@@ -1260,13 +1253,13 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
         sorting_analyzer.extensions[si_ext_name] = ext
 
 
-def _load_metrics_runs(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
-    """Read MetricsRun instances and reconstruct SI's ``quality_metrics`` and
+def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
+    """Read UnitMetrics instances and reconstruct SI's ``quality_metrics`` and
     ``valid_unit_periods`` extensions.
 
-    Each MetricsRun is a curation run; its typed columns populate
+    Each UnitMetrics is a curation run; its typed columns populate
     ``quality_metrics``, and its ``valid_intervals`` (if present) populate
-    ``valid_unit_periods``. For v1 we expect at most one MetricsRun per file
+    ``valid_unit_periods``. For v1 we expect at most one UnitMetrics per file
     and route it directly. Multi-run support (each run distinguished by name
     or parameter context) is a follow-up.
     """
@@ -1274,12 +1267,12 @@ def _load_metrics_runs(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
     from spikeinterface.core.base import unit_period_dtype
     from spikeinterface.core.sortinganalyzer import get_extension_class
 
-    metrics_runs = getattr(extensions, "metrics_runs", None)
-    if not metrics_runs:
+    unit_metrics = getattr(extensions, "unit_metrics", None)
+    if not unit_metrics:
         return
 
-    # Iterate over MetricsRun instances (LabelledDict keyed by name)
-    runs = metrics_runs.values() if hasattr(metrics_runs, "values") else [metrics_runs]
+    # Iterate over UnitMetrics instances (LabelledDict keyed by name)
+    runs = unit_metrics.values() if hasattr(unit_metrics, "values") else [unit_metrics]
     for nwb_table in runs:
         unit_ids = sorting_analyzer.unit_ids
         per_extension_columns: dict[str, dict[str, np.ndarray]] = {}

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -366,9 +366,7 @@ def _convert_unit_metrics(
 
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
-    as typed columns. If ``valid_unit_periods`` is also computed, the per-unit
-    valid windows are written as ``obs_intervals`` on the table. Returns
-    ``None`` when ``quality_metrics`` is not computed.
+    as typed columns. Returns ``None`` when ``quality_metrics`` is not computed.
     """
     qm_ext = sorting_analyzer.get_extension("quality_metrics")
     if qm_ext is None:
@@ -416,52 +414,51 @@ def _convert_unit_metrics(
             )
         )
 
-    # If valid_unit_periods is computed, store the per-unit windows as
-    # obs_intervals on this UnitMetrics instance. obs_intervals is ragged by row
-    # (one row per unit), each cell holds the list of (start, stop) windows
-    # used to restrict that unit's metric computation.
-    vup_ext = sorting_analyzer.get_extension("valid_unit_periods")
-    if vup_ext is not None:
-        if sorting_analyzer.get_num_segments() > 1:
-            raise NotImplementedError(
-                "valid_unit_periods round-trip is single-segment only; "
-                "multi-segment support not yet implemented."
-            )
-        sampling_frequency = sorting_analyzer.sampling_frequency
-        valid_periods_data = vup_ext.get_data(outputs="numpy")
-        per_unit_windows: list[list[tuple[float, float]]] = [[] for _ in range(n_units)]
-        for period in valid_periods_data:
-            unit_idx = int(period["unit_index"])
-            start_s = float(period["start_sample_index"]) / sampling_frequency
-            stop_s = float(period["end_sample_index"]) / sampling_frequency
-            per_unit_windows[unit_idx].append((start_s, stop_s))
-
-        flat_intervals: list[list[float]] = []
-        cumulative = []
-        running = 0
-        for windows in per_unit_windows:
-            for start_s, stop_s in windows:
-                flat_intervals.append([start_s, stop_s])
-            running += len(windows)
-            cumulative.append(running)
-
-        obs_intervals_vd = VectorData(
-            name="obs_intervals",
-            data=np.array(flat_intervals, dtype=np.float64) if flat_intervals else np.zeros((0, 2)),
-            description="Per-unit observation intervals (start, stop) in seconds.",
-        )
-        obs_intervals_index = VectorIndex(
-            name="obs_intervals_index",
-            data=np.array(cumulative, dtype=np.int64),
-            target=obs_intervals_vd,
-        )
-        columns.append(obs_intervals_vd)
-        columns.append(obs_intervals_index)
-
     return UnitMetrics(
         name="quality_metrics",
         description="Run-dependent per-unit metrics from one analysis run.",
         columns=columns,
+    )
+
+
+def _convert_valid_unit_periods(
+    sorting_analyzer: "SortingAnalyzer",
+    units_table=None,
+) -> ValidUnitPeriods | None:
+    ext = sorting_analyzer.get_extension("valid_unit_periods")
+    if ext is None:
+        return None
+    valid_periods_data = ext.get_data(outputs="numpy")
+    sampling_frequency = sorting_analyzer.sampling_frequency
+
+    start_times = []
+    stop_times = []
+    unit_indices = []
+
+    for period in valid_periods_data:
+        start_times.append(float(period["start_sample_index"]) / sampling_frequency)
+        stop_times.append(float(period["end_sample_index"]) / sampling_frequency)
+        unit_indices.append(int(period["unit_index"]))
+
+    vup_unit_column = DynamicTableRegion(
+        name="unit",
+        data=unit_indices,
+        description="Reference to units table for each valid period.",
+        table=units_table,
+    )
+
+    return ValidUnitPeriods(
+        name="valid_unit_periods",
+        description="Valid time periods per unit from spike sorting quality estimation.",
+        columns=[
+            VectorData(
+                name="start_time", data=start_times, description="Start time of each valid period in seconds."
+            ),
+            VectorData(
+                name="stop_time", data=stop_times, description="Stop time of each valid period in seconds."
+            ),
+            vup_unit_column,
+        ],
     )
 
 
@@ -668,6 +665,10 @@ def _convert_all_extensions(sorting_analyzer, nwbfile):  # noqa: C901
     unit_metrics = _convert_unit_metrics(sorting_analyzer, nwbfile)
     if unit_metrics is not None:
         converted["__unit_metrics__"] = unit_metrics
+
+    vup = _convert_valid_unit_periods(sorting_analyzer, units_table=nwbfile.units)
+    if vup is not None:
+        converted["valid_unit_periods"] = vup
 
     return converted
 
@@ -896,6 +897,7 @@ def read_sorting_analyzer_from_nwb(
             _load_spike_locations(extensions, sorting_analyzer)
             _load_pca_projections(extensions, sorting_analyzer)
             _load_unit_metrics(extensions, sorting_analyzer)
+            _load_valid_unit_periods_from_nwb(extensions, sorting_analyzer)
 
         # Cell-intrinsic metrics live on nwbfile.units as typed columns; read
         # them by column type so the SI extension binding survives even if a
@@ -1244,17 +1246,14 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
 
 
 def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
-    """Read UnitMetrics instances and reconstruct SI's ``quality_metrics`` and
-    ``valid_unit_periods`` extensions.
+    """Read UnitMetrics instances and reconstruct SI's ``quality_metrics`` extension.
 
-    Each UnitMetrics is a curation run; its typed columns populate
-    ``quality_metrics``, and its ``obs_intervals`` (if present) populate
-    ``valid_unit_periods``. For v1 we expect at most one UnitMetrics per file
-    and route it directly. Multi-run support (each run distinguished by name
-    or parameter context) is a follow-up.
+    Each UnitMetrics is a curation run whose typed (and plain) columns populate
+    ``quality_metrics``. For v1 we expect at most one UnitMetrics per file and
+    route it directly. Multi-run support (each run distinguished by name or
+    parameter context) is a follow-up.
     """
     import pandas as pd
-    from spikeinterface.core.base import unit_period_dtype
     from spikeinterface.core.sortinganalyzer import get_extension_class
 
     unit_metrics = getattr(extensions, "unit_metrics", None)
@@ -1269,7 +1268,7 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
         per_extension_params: dict[str, dict] = {}
 
         for col_name in nwb_table.colnames:
-            if col_name in ("unit", "obs_intervals", "obs_intervals_index"):
+            if col_name == "unit":
                 continue
             col = nwb_table[col_name]
             # First try the typed-column registry (empty in v1; kept for forward
@@ -1303,44 +1302,34 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
             ext.run_info = {"run_completed": True, "runtime_s": 0.0}
             sorting_analyzer.extensions[si_ext_name] = ext
 
-        # Reconstruct valid_unit_periods from obs_intervals if present.
-        if "obs_intervals" in nwb_table.colnames:
-            # nwb_table["obs_intervals"] returns the VectorIndex (the
-            # per-row cumulative boundaries); its .target is the underlying
-            # VectorData with the flat (total_intervals, 2) array.
-            obs_intervals_vi = nwb_table["obs_intervals"]
-            cum = np.asarray(obs_intervals_vi.data[:])
-            flat = np.asarray(obs_intervals_vi.target.data[:])
-            sampling_frequency = sorting_analyzer.sampling_frequency
 
-            periods_list = []
-            prev = 0
-            for unit_idx, end in enumerate(cum):
-                for row in flat[prev:end]:
-                    start_s, stop_s = float(row[0]), float(row[1])
-                    periods_list.append(
-                        (
-                            0,
-                            int(round(start_s * sampling_frequency)),
-                            int(round(stop_s * sampling_frequency)),
-                            unit_idx,
-                        )
-                    )
-                prev = int(end)
+def _load_valid_unit_periods_from_nwb(extensions, sorting_analyzer):
+    from spikeinterface.core.base import unit_period_dtype
+    from spikeinterface.core.sortinganalyzer import get_extension_class
 
-            if periods_list:
-                vup_array = np.array(periods_list, dtype=unit_period_dtype)
-                vup_class = get_extension_class("valid_unit_periods")
-                if vup_class is not None:
-                    vup_ext = vup_class(sorting_analyzer)
-                    vup_ext.set_params(
-                        method="user_defined",
-                        user_defined_periods=vup_array,
-                        minimum_valid_period_duration=0,
-                    )
-                    vup_ext.data["valid_unit_periods"] = vup_array
-                    vup_ext.run_info = {"run_completed": True, "runtime_s": 0.0}
-                    sorting_analyzer.extensions["valid_unit_periods"] = vup_ext
+    valid_periods_nwb = getattr(extensions, "valid_unit_periods", None)
+    if valid_periods_nwb is None:
+        return
+
+    start_times = np.array(valid_periods_nwb["start_time"][:], dtype=np.float64)
+    stop_times = np.array(valid_periods_nwb["stop_time"][:], dtype=np.float64)
+    unit_indices = np.array(valid_periods_nwb["unit"].data[:], dtype=np.int64)
+
+    sampling_frequency = sorting_analyzer.sampling_frequency
+    n_periods = len(start_times)
+
+    valid_periods = np.zeros(n_periods, dtype=unit_period_dtype)
+    valid_periods["segment_index"] = 0
+    valid_periods["start_sample_index"] = np.round(start_times * sampling_frequency).astype(np.int64)
+    valid_periods["end_sample_index"] = np.round(stop_times * sampling_frequency).astype(np.int64)
+    valid_periods["unit_index"] = unit_indices
+
+    ext_class = get_extension_class("valid_unit_periods")
+    ext = ext_class(sorting_analyzer)
+    ext.set_params(method="user_defined", user_defined_periods=valid_periods, minimum_valid_period_duration=0)
+    ext.data["valid_unit_periods"] = valid_periods
+    ext.run_info = {"run_completed": True, "runtime_s": 0.0}
+    sorting_analyzer.extensions["valid_unit_periods"] = ext
 
 
 def _load_pca_projections(extensions, sorting_analyzer: "SortingAnalyzer") -> None:

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -10,6 +10,7 @@ from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries
 
 if TYPE_CHECKING:
+    import pandas as pd
     from spikeinterface.core import SortingAnalyzer
 
 from ndx_spikesorting import (

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -28,6 +28,7 @@ from ndx_spikesorting import (
     PCAProjectionsByChannel,
     PCAProjectionsConcatenated,
     FiringRate,
+    MetricVectorData,
     UnitMetrics,
     ValidUnitPeriods,
     SpikeSortingExtensions,
@@ -433,17 +434,53 @@ def _add_cell_intrinsic_columns_to_units(
         )
 
 
+def _units_table_id_lookup(units_table) -> dict[str, int]:
+    """Map each unit id in an NWB Units table to its row index.
+
+    Prefers the ``unit_name`` column (canonical when string unit ids are
+    written via neuroconv); falls back to the ``id`` ElementIdentifiers.
+    Keys are stringified to match SpikeInterface's stringification on read.
+    """
+    if "unit_name" in units_table.colnames:
+        ids = list(units_table["unit_name"][:])
+    else:
+        ids = list(units_table.id[:])
+    return {str(uid): i for i, uid in enumerate(ids)}
+
+
+def _analyzer_positions_to_units_rows(sorting_analyzer, units_table) -> list[int]:
+    """For each analyzer position i, return the nwbfile.units row index for that unit id.
+
+    Raises ValueError if an analyzer unit id has no matching row in the units
+    table. This is what makes the writer order-independent: the resulting list,
+    used as DTR data, points each row of UnitMetrics at the right nwbfile.units
+    row regardless of whether the two tables share an ordering.
+    """
+    id_lookup = _units_table_id_lookup(units_table)
+    analyzer_ids = [str(uid) for uid in sorting_analyzer.unit_ids]
+    missing = [uid for uid in analyzer_ids if uid not in id_lookup]
+    if missing:
+        raise ValueError(
+            f"sorting_analyzer.unit_ids has no matching row in nwbfile.units for: {missing}. "
+            f"Available units in nwbfile.units: {sorted(id_lookup.keys())}"
+        )
+    return [id_lookup[uid] for uid in analyzer_ids]
+
+
 def _convert_unit_metrics(
     sorting_analyzer: "SortingAnalyzer",
     nwbfile: NWBFile,
+    time_support_ref: "ValidUnitPeriods | None" = None,
 ) -> UnitMetrics | None:
     """Build a UnitMetrics instance from SI's ``quality_metrics`` extension.
 
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
-    as typed columns. If ``valid_unit_periods`` is also computed, the per-unit
-    valid windows are written as ``time_support`` on the table.
-    Returns ``None`` when ``quality_metrics`` is not computed.
+    as ``MetricVectorData`` columns. When ``time_support_ref`` is provided, each
+    metric column gets a ``time_support`` attribute pointing to that
+    ``ValidUnitPeriods`` table, so the per-unit constraint intervals are stored
+    once and referenced by every column they apply to. Returns ``None`` when
+    neither ``quality_metrics`` nor ``template_metrics`` is computed.
     """
     qm_ext = sorting_analyzer.get_extension("quality_metrics")
     tm_ext = sorting_analyzer.get_extension("template_metrics")
@@ -471,86 +508,33 @@ def _convert_unit_metrics(
     else:
         df = tm_ext.get_data()
 
-    n_units = len(sorting_analyzer.unit_ids)
-    qm_params = qm_ext.params or {} if qm_ext is not None else {}
-
-    # Per-row unit DTR pointing back to nwbfile.units (one row per unit).
+    # Per-row unit DTR pointing back to nwbfile.units (one row per unit). We
+    # resolve each analyzer unit_id to a nwbfile.units row index by identity
+    # rather than position, so the DTR stays correct even if nwbfile.units is
+    # reordered or interleaved with units we don't own.
+    dtr_data = _analyzer_positions_to_units_rows(sorting_analyzer, nwbfile.units)
     unit_column = DynamicTableRegion(
         name="unit",
-        data=list(range(n_units)),
+        data=dtr_data,
         description="Reference to nwbfile.units row this metric value applies to.",
         table=nwbfile.units,
     )
 
     columns = [unit_column]
 
-    # Track which DataFrame columns we have already written via typed-column
-    # paths so we do not duplicate them as plain VectorData below. Currently
-    # empty (no run-dependent typed columns committed in v1), but keeps the
-    # design open for adding typed columns in a later version.
-    typed_column_names: set[str] = set()
-    for col_cls, (si_name, _) in UNIT_METRICS_TYPED_COLUMNS.items():
-        if si_name not in df.columns:
-            continue
-        col_kwargs = _build_column_kwargs(col_cls, si_name, df[si_name].to_numpy(), qm_params)
-        columns.append(col_cls(**col_kwargs))
-        typed_column_names.add(si_name)
-
-    # The remaining quality_metrics DataFrame columns become plain VectorData
-    # on the UnitMetrics instance. Column names are preserved so the loader can
-    # reconstruct SI's quality_metrics extension on read.
+    # Each metric column becomes a MetricVectorData so it can carry the optional
+    # time_support reference. Column names are preserved so the read path can
+    # route each column to the right SI extension via COLUMN_TO_EXTENSION.
     for col_name in df.columns:
-        if col_name in typed_column_names:
-            continue
-        col_values = df[col_name].to_numpy()
-        # Coerce to float for storage; NaNs are preserved.
-        columns.append(
-            VectorData(
-                name=col_name,
-                data=col_values.astype(float),
-                description=f"Run-dependent metric: {col_name}.",
-            )
+        col_values = df[col_name].to_numpy().astype(float)
+        col_kwargs = dict(
+            name=col_name,
+            data=col_values,
+            description=f"Run-dependent metric: {col_name}.",
         )
-
-    qm_periods = qm_params.get("periods") if qm_params else None
-    if qm_periods is not None and len(qm_periods) > 0:
-        if sorting_analyzer.get_num_segments() > 1:
-            raise NotImplementedError(
-                "time_support round-trip is single-segment only; "
-                "multi-segment support not yet implemented."
-            )
-        sampling_frequency = sorting_analyzer.sampling_frequency
-        per_unit_windows: list[list[tuple[float, float]]] = [[] for _ in range(n_units)]
-        for period in qm_periods:
-            unit_index = int(period["unit_index"])
-            start_s = float(period["start_sample_index"]) / sampling_frequency
-            stop_s = float(period["end_sample_index"]) / sampling_frequency
-            per_unit_windows[unit_index].append((start_s, stop_s))
-
-        flat_intervals: list[list[float]] = []
-        cumulative = []
-        running = 0
-        for windows in per_unit_windows:
-            for start_s, stop_s in windows:
-                flat_intervals.append([start_s, stop_s])
-            running += len(windows)
-            cumulative.append(running)
-
-        time_support_vd = VectorData(
-            name="time_support",
-            data=np.array(flat_intervals, dtype=np.float64) if flat_intervals else np.zeros((0, 2)),
-            description=(
-                "Per-unit time intervals (start, stop) in seconds over which this row's "
-                "metric values were computed."
-            ),
-        )
-        time_support_index = VectorIndex(
-            name="time_support_index",
-            data=np.array(cumulative, dtype=np.int64),
-            target=time_support_vd,
-        )
-        columns.append(time_support_vd)
-        columns.append(time_support_index)
+        if time_support_ref is not None:
+            col_kwargs["time_support"] = time_support_ref
+        columns.append(MetricVectorData(**col_kwargs))
 
     return UnitMetrics(
         name="quality_metrics",
@@ -559,28 +543,45 @@ def _convert_unit_metrics(
     )
 
 
-def _convert_valid_unit_periods(
+def _build_valid_unit_periods(
     sorting_analyzer: "SortingAnalyzer",
     units_table=None,
 ) -> ValidUnitPeriods | None:
-    ext = sorting_analyzer.get_extension("valid_unit_periods")
-    if ext is None:
-        return None
-    valid_periods_data = ext.get_data(outputs="numpy")
+    """Build a ValidUnitPeriods table from the best available periods source.
+
+    Prefers ``quality_metrics.params["periods"]`` when set (that array is what
+    the metric columns are actually constrained by). Falls back to the SI
+    ``valid_unit_periods`` extension when only that is available. Returns
+    ``None`` if neither source has periods.
+    """
+    qm_ext = sorting_analyzer.get_extension("quality_metrics")
+    qm_periods = qm_ext.params.get("periods") if qm_ext is not None and qm_ext.params else None
+    if qm_periods is not None and len(qm_periods) > 0:
+        periods = qm_periods
+    else:
+        vup_ext = sorting_analyzer.get_extension("valid_unit_periods")
+        if vup_ext is None:
+            return None
+        periods = vup_ext.get_data(outputs="numpy")
+        if len(periods) == 0:
+            return None
+
+    if sorting_analyzer.get_num_segments() > 1:
+        raise NotImplementedError(
+            "ValidUnitPeriods round-trip is single-segment only; "
+            "multi-segment support not yet implemented."
+        )
+
     sampling_frequency = sorting_analyzer.sampling_frequency
+    analyzer_pos_to_row = _analyzer_positions_to_units_rows(sorting_analyzer, units_table)
 
-    start_times = []
-    stop_times = []
-    unit_indices = []
-
-    for period in valid_periods_data:
-        start_times.append(float(period["start_sample_index"]) / sampling_frequency)
-        stop_times.append(float(period["end_sample_index"]) / sampling_frequency)
-        unit_indices.append(int(period["unit_index"]))
+    start_times = [float(p["start_sample_index"]) / sampling_frequency for p in periods]
+    stop_times = [float(p["end_sample_index"]) / sampling_frequency for p in periods]
+    unit_row_indices = [analyzer_pos_to_row[int(p["unit_index"])] for p in periods]
 
     vup_unit_column = DynamicTableRegion(
         name="unit",
-        data=unit_indices,
+        data=unit_row_indices,
         description="Reference to units table for each valid period.",
         table=units_table,
     )
@@ -797,16 +798,21 @@ def _convert_all_extensions(sorting_analyzer, nwbfile):  # noqa: C901
             raise ValueError("PCA projections require waveforms to be computed.")
         converted.update(_convert_pca(sorting_analyzer, nwbfile, converted["waveforms"]))
 
+    # Build ValidUnitPeriods first (preferring quality_metrics.params["periods"]
+    # when set, since that's what the metric columns are actually constrained
+    # by). UnitMetrics columns reference this table via their time_support
+    # attribute, so the intervals are stored once and pointed to by every
+    # column they apply to.
+    vup = _build_valid_unit_periods(sorting_analyzer, units_table=nwbfile.units)
+    if vup is not None:
+        converted["valid_unit_periods"] = vup
+
     # Run-dependent metrics flow into a UnitMetrics instance (or several, as
     # support for multiple curation runs is added). For v1 there is one
     # UnitMetrics per file, sourced from SI's quality_metrics extension.
-    unit_metrics = _convert_unit_metrics(sorting_analyzer, nwbfile)
+    unit_metrics = _convert_unit_metrics(sorting_analyzer, nwbfile, time_support_ref=vup)
     if unit_metrics is not None:
         converted["__unit_metrics__"] = unit_metrics
-
-    vup = _convert_valid_unit_periods(sorting_analyzer, units_table=nwbfile.units)
-    if vup is not None:
-        converted["valid_unit_periods"] = vup
 
     return converted
 
@@ -1383,6 +1389,54 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
         sorting_analyzer.extensions[si_ext_name] = ext
 
 
+def _collect_unit_metrics_columns(nwb_table, sorting_analyzer):
+    """Walk a UnitMetrics table once and return (per_extension_columns, time_support_link).
+
+    Reorders each column's row values into analyzer-unit-position order using
+    the DTR-resolved row → analyzer position map, so the resulting arrays are
+    aligned with ``sorting_analyzer.unit_ids`` regardless of whether the on-disk
+    row order matches.
+    """
+    import warnings
+
+    row_to_analyzer_pos = _dtr_rows_to_analyzer_positions(nwb_table["unit"], sorting_analyzer)
+    # Permutation that places UnitMetrics row i's value at the slot corresponding
+    # to its analyzer unit position in the output array.
+    reorder = np.argsort(row_to_analyzer_pos)
+
+    per_extension_columns: dict[str, dict[str, np.ndarray]] = {}
+    time_support_link = None
+    for col_name in nwb_table.colnames:
+        if col_name == "unit":
+            continue
+        col = nwb_table[col_name]
+        if time_support_link is None:
+            time_support_link = getattr(col, "time_support", None)
+        # Typed-column registry path (empty in v1; future-proofing).
+        matched = False
+        for col_cls, (si_name, si_ext_name) in UNIT_METRICS_TYPED_COLUMNS.items():
+            if isinstance(col, col_cls):
+                raw = np.asarray(col.data[:])
+                per_extension_columns.setdefault(si_ext_name, {})[si_name] = raw[reorder]
+                matched = True
+                break
+        if matched:
+            continue
+        targets = COLUMN_TO_EXTENSION.get(col_name)
+        if targets is None:
+            warnings.warn(
+                f"Column {col_name!r} on UnitMetrics is not in "
+                "COLUMN_TO_EXTENSION; routing to quality_metrics by default. "
+                "Update the dict in utils.py to silence this warning.",
+                stacklevel=2,
+            )
+            targets = ("quality_metrics",)
+        values = np.asarray(col.data[:])[reorder]
+        for si_ext_name in targets:
+            per_extension_columns.setdefault(si_ext_name, {})[col_name] = values
+    return per_extension_columns, time_support_link
+
+
 def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
     """Read UnitMetrics instances and reconstruct the relevant SI extensions.
 
@@ -1394,8 +1448,6 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
     dict falls back to ``quality_metrics`` (matching pre-fix behavior) and is
     surfaced via a warning so the dict can be kept in sync with SI's registries.
     """
-    import warnings
-
     import pandas as pd
     from spikeinterface.core.base import unit_period_dtype
     from spikeinterface.core.sortinganalyzer import get_extension_class
@@ -1408,38 +1460,10 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
     runs = unit_metrics.values() if hasattr(unit_metrics, "values") else [unit_metrics]
     for nwb_table in runs:
         unit_ids = sorting_analyzer.unit_ids
-        per_extension_columns: dict[str, dict[str, np.ndarray]] = {}
         per_extension_params: dict[str, dict] = {}
-
-        for col_name in nwb_table.colnames:
-            if col_name in ("unit", "time_support", "time_support_index"):
-                continue
-            col = nwb_table[col_name]
-            # First try the typed-column registry (empty in v1; kept for forward
-            # compatibility when run-dependent typed columns are added).
-            matched = False
-            for col_cls, (si_name, si_ext_name) in UNIT_METRICS_TYPED_COLUMNS.items():
-                if isinstance(col, col_cls):
-                    per_extension_columns.setdefault(si_ext_name, {})[si_name] = np.asarray(col.data[:])
-                    matched = True
-                    break
-            if matched:
-                continue
-            # Route plain VectorData columns by name via COLUMN_TO_EXTENSION.
-            # Replicate into every target extension when the column belongs to
-            # more than one (the SI extension-aliasing case).
-            targets = COLUMN_TO_EXTENSION.get(col_name)
-            if targets is None:
-                warnings.warn(
-                    f"Column {col_name!r} on UnitMetrics is not in "
-                    "COLUMN_TO_EXTENSION; routing to quality_metrics by default. "
-                    "Update the dict in utils.py to silence this warning.",
-                    stacklevel=2,
-                )
-                targets = ("quality_metrics",)
-            values = np.asarray(col.data[:])
-            for si_ext_name in targets:
-                per_extension_columns.setdefault(si_ext_name, {})[col_name] = values
+        per_extension_columns, time_support_link = _collect_unit_metrics_columns(
+            nwb_table, sorting_analyzer
+        )
 
         for si_ext_name, columns_dict in per_extension_columns.items():
             ext_class = get_extension_class(si_ext_name)
@@ -1471,43 +1495,58 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
             ext.run_info = {"run_completed": True, "runtime_s": 0.0}
             sorting_analyzer.extensions[si_ext_name] = ext
 
-        # Restore quality_metrics.params["periods"] from the ragged time_support
-        # column when present, so SI sees the same per-unit windows the metric
-        # values were computed over.
-        qm_periods = _periods_from_time_support(nwb_table, sorting_analyzer, unit_period_dtype)
+        # Restore quality_metrics.params["periods"] from the column-level
+        # time_support reference, when present.
+        qm_periods = _periods_from_time_support_link(time_support_link, sorting_analyzer, unit_period_dtype)
         qm_ext = sorting_analyzer.extensions.get("quality_metrics")
         if qm_periods is not None and qm_ext is not None:
             qm_ext.params["periods"] = qm_periods
 
 
-def _periods_from_time_support(nwb_table, sorting_analyzer, unit_period_dtype):
-    """Build SI's structured periods array from a UnitMetrics time_support column.
+def _dtr_rows_to_analyzer_positions(unit_dtr, sorting_analyzer) -> np.ndarray:
+    """Map DTR row indices (into nwbfile.units) into analyzer unit positions.
 
-    Returns None when the table has no time_support column. Single-segment only
-    (segment_index=0).
+    DTR ``data[i]`` is the nwbfile.units row index for the i-th referencing row.
+    We resolve each row back to its unit id (preferring ``unit_name``) and look
+    that id up in ``sorting_analyzer.unit_ids`` so the resulting integer is the
+    correct positional index into the analyzer regardless of any reordering.
     """
-    if "time_support" not in nwb_table.colnames:
+    units_table = unit_dtr.table
+    row_to_id = {row_idx: uid for uid, row_idx in _units_table_id_lookup(units_table).items()}
+    analyzer_id_to_pos = {str(uid): pos for pos, uid in enumerate(sorting_analyzer.unit_ids)}
+    dtr_rows = np.asarray(unit_dtr.data[:], dtype=np.int64)
+    out = np.empty(len(dtr_rows), dtype=np.int64)
+    for i, row_idx in enumerate(dtr_rows):
+        uid = row_to_id[int(row_idx)]
+        if uid not in analyzer_id_to_pos:
+            raise ValueError(
+                f"DTR references nwbfile.units row {int(row_idx)} (unit id {uid!r}), "
+                f"but that id is not in sorting_analyzer.unit_ids: {list(analyzer_id_to_pos.keys())}"
+            )
+        out[i] = analyzer_id_to_pos[uid]
+    return out
+
+
+def _periods_from_time_support_link(vup_table, sorting_analyzer, unit_period_dtype):
+    """Build SI's structured periods array from a linked ValidUnitPeriods table.
+
+    ``vup_table`` is a ``ValidUnitPeriods`` (TimeIntervals subclass) referenced
+    from a metric column's ``time_support`` attribute. Returns ``None`` when no
+    link was set. Single-segment only (segment_index=0).
+    """
+    if vup_table is None:
         return None
-    # When the column is ragged, nwb_table["time_support"] resolves to its
-    # VectorIndex (offsets in .data, underlying values in .target.data).
-    ts_accessor = nwb_table["time_support"]
-    end_offsets = np.asarray(ts_accessor.data[:], dtype=np.int64)
-    flat_intervals = np.asarray(ts_accessor.target.data[:], dtype=np.float64)
-    unit_indices_col = np.asarray(nwb_table["unit"].data[:], dtype=np.int64)
+    start_times = np.asarray(vup_table["start_time"][:], dtype=np.float64)
+    stop_times = np.asarray(vup_table["stop_time"][:], dtype=np.float64)
+    analyzer_positions = _dtr_rows_to_analyzer_positions(vup_table["unit"], sorting_analyzer)
     sampling_frequency = sorting_analyzer.sampling_frequency
 
-    n_periods = int(end_offsets[-1]) if len(end_offsets) > 0 else 0
+    n_periods = len(start_times)
     periods = np.zeros(n_periods, dtype=unit_period_dtype)
-    cursor = 0
-    for row_idx, end in enumerate(end_offsets):
-        unit_index = int(unit_indices_col[row_idx])
-        for window in flat_intervals[cursor:end]:
-            start_s, stop_s = float(window[0]), float(window[1])
-            periods["segment_index"][cursor] = 0
-            periods["start_sample_index"][cursor] = int(round(start_s * sampling_frequency))
-            periods["end_sample_index"][cursor] = int(round(stop_s * sampling_frequency))
-            periods["unit_index"][cursor] = unit_index
-            cursor += 1
+    periods["segment_index"] = 0
+    periods["start_sample_index"] = np.round(start_times * sampling_frequency).astype(np.int64)
+    periods["end_sample_index"] = np.round(stop_times * sampling_frequency).astype(np.int64)
+    periods["unit_index"] = analyzer_positions
     return periods
 
 
@@ -1521,7 +1560,7 @@ def _load_valid_unit_periods_from_nwb(extensions, sorting_analyzer):
 
     start_times = np.array(valid_periods_nwb["start_time"][:], dtype=np.float64)
     stop_times = np.array(valid_periods_nwb["stop_time"][:], dtype=np.float64)
-    unit_indices = np.array(valid_periods_nwb["unit"].data[:], dtype=np.int64)
+    analyzer_positions = _dtr_rows_to_analyzer_positions(valid_periods_nwb["unit"], sorting_analyzer)
 
     sampling_frequency = sorting_analyzer.sampling_frequency
     n_periods = len(start_times)
@@ -1530,7 +1569,7 @@ def _load_valid_unit_periods_from_nwb(extensions, sorting_analyzer):
     valid_periods["segment_index"] = 0
     valid_periods["start_sample_index"] = np.round(start_times * sampling_frequency).astype(np.int64)
     valid_periods["end_sample_index"] = np.round(stop_times * sampling_frequency).astype(np.int64)
-    valid_periods["unit_index"] = unit_indices
+    valid_periods["unit_index"] = analyzer_positions
 
     ext_class = get_extension_class("valid_unit_periods")
     ext = ext_class(sorting_analyzer)

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -26,10 +26,41 @@ from ndx_spikesorting import (
     AmplitudeScalings,
     PCAProjectionsByChannel,
     PCAProjectionsConcatenated,
-    ValidUnitPeriods,
+    FiringRate,
+    MetricsRun,
     SpikeSortingExtensions,
     SpikeSortingContainer,
 )
+
+# ---------------------------------------------------------------------------
+# Canonical column registry
+# ---------------------------------------------------------------------------
+# Maps each typed VectorData column class to:
+#   - the SI metric column name it represents (the DataFrame column key)
+#   - the SI extension name it should be routed to on read
+#   - which side of the cell-vs-algorithm split it lives on
+#
+# This mapping is the single point of SI knowledge in the loader; the spec
+# itself stays tool-agnostic.
+
+CELL_INTRINSIC_COLUMNS = {
+    # column class -> (si_metric_name, si_extension_name)
+    # v1 canonizes one column to illustrate the pattern. Other candidates
+    # (peak_to_trough_duration, trough_half_width, amplitude_median) round-trip
+    # as plain VectorData columns on nwbfile.units until they get their own
+    # follow-up PR with cross-pipeline-variability discussion.
+    FiringRate: ("firing_rate", "spiketrain_metrics"),
+}
+
+# Run-dependent metrics flow into MetricsRun instances as plain VectorData
+# columns. No typed-column classes are committed in v1 because each candidate
+# (Snr, PresenceRatio, IsiViolationsRatio, AmplitudeCutoff) requires multiple
+# attributes to capture cross-pipeline variability and the field has not
+# converged on canonical conventions. The writer below pulls SI's
+# quality_metrics DataFrame columns and writes them as untyped float columns
+# on the MetricsRun instance, preserving column names so the SI extension can
+# be reconstructed on read.
+RUN_DEPENDENT_COLUMNS: dict = {}
 
 
 def templates_to_dense(templates: Templates, num_channels: int) -> np.ndarray:
@@ -299,44 +330,176 @@ def _convert_spike_vector_extension(
     return nwb_class(name=extension_name, data=data, data_index=data_index)
 
 
-def _convert_valid_unit_periods(
+def _add_cell_intrinsic_columns_to_units(
     sorting_analyzer: "SortingAnalyzer",
-    extension_name: str,
-    nwb_class: type,
-    units_table: DynamicTableRegion = None,
-) -> ValidUnitPeriods:
-    ext = sorting_analyzer.get_extension("valid_unit_periods")
-    valid_periods_data = ext.get_data(outputs="numpy")
-    sampling_frequency = sorting_analyzer.sampling_frequency
+    nwbfile: NWBFile,
+) -> None:
+    """Add canonical cell-intrinsic metric columns to ``nwbfile.units``.
 
-    start_times = []
-    stop_times = []
-    unit_indices = []
+    Pulls per-unit values from SI's ``template_metrics`` and ``spiketrain_metrics``
+    DataFrames and writes them as typed VectorData columns on the existing
+    ``nwbfile.units`` table. Each column carries its type tag (e.g. ``FiringRate``)
+    so a reader can recover the canonical mapping back to SI extensions.
 
-    for period in valid_periods_data:
-        start_times.append(float(period["start_sample_index"]) / sampling_frequency)
-        stop_times.append(float(period["end_sample_index"]) / sampling_frequency)
-        unit_indices.append(int(period["unit_index"]))
+    The rows of ``nwbfile.units`` are assumed to be aligned with
+    ``sorting_analyzer.unit_ids`` (neuroconv's ``add_sorting_to_nwbfile``
+    preserves this order).
+    """
+    if nwbfile.units is None:
+        return
 
-    vup_unit_column = DynamicTableRegion(
+    n_units = len(sorting_analyzer.unit_ids)
+    if len(nwbfile.units) != n_units:
+        raise ValueError(
+            f"Mismatch between nwbfile.units ({len(nwbfile.units)} rows) and "
+            f"sorting_analyzer.unit_ids ({n_units} units). Add the sorting to the "
+            "NWB file before calling add_sorting_analyzer_to_nwbfile."
+        )
+
+    # Cache SI extension DataFrames by name so we only pull each once.
+    si_extension_data: dict[str, "pd.DataFrame"] = {}
+    for col_cls, (si_name, si_ext_name) in CELL_INTRINSIC_COLUMNS.items():
+        if si_ext_name not in si_extension_data:
+            ext = sorting_analyzer.get_extension(si_ext_name)
+            si_extension_data[si_ext_name] = ext.get_data() if ext is not None else None
+        df = si_extension_data[si_ext_name]
+        if df is None or si_name not in df.columns:
+            continue
+        if si_name in nwbfile.units.colnames:
+            continue  # already populated
+        nwbfile.units.add_column(
+            name=si_name,
+            description=col_cls.__doc__ or si_name,
+            data=df[si_name].to_numpy(),
+            col_cls=col_cls,
+        )
+
+
+def _convert_metrics_run(
+    sorting_analyzer: "SortingAnalyzer",
+    nwbfile: NWBFile,
+) -> MetricsRun | None:
+    """Build a MetricsRun instance from SI's ``quality_metrics`` extension.
+
+    Each row of the table references one unit (via the ``unit``
+    ``DynamicTableRegion``) and carries that unit's run-dependent metric values
+    as typed columns. If ``valid_unit_periods`` is also computed, the per-unit
+    valid windows are written as ``valid_intervals`` on the table. Returns
+    ``None`` when ``quality_metrics`` is not computed.
+    """
+    qm_ext = sorting_analyzer.get_extension("quality_metrics")
+    if qm_ext is None:
+        return None
+
+    df = qm_ext.get_data()
+    n_units = len(sorting_analyzer.unit_ids)
+    qm_params = qm_ext.params or {}
+
+    # Per-row unit DTR pointing back to nwbfile.units (one row per unit).
+    unit_column = DynamicTableRegion(
         name="unit",
-        data=unit_indices,
-        description="Reference to units table for each valid period.",
-        table=units_table,
+        data=list(range(n_units)),
+        description="Reference to nwbfile.units row this metric value applies to.",
+        table=nwbfile.units,
     )
 
-    return nwb_class(
-        name=extension_name,
-        description="Valid time periods per unit from spike sorting quality estimation.",
-        columns=[
+    columns = [unit_column]
+
+    # Track which DataFrame columns we have already written via typed-column
+    # paths so we do not duplicate them as plain VectorData below. Currently
+    # empty (no run-dependent typed columns committed in v1), but keeps the
+    # design open for adding typed columns in a later version.
+    typed_column_names: set[str] = set()
+    for col_cls, (si_name, _) in RUN_DEPENDENT_COLUMNS.items():
+        if si_name not in df.columns:
+            continue
+        col_kwargs = _build_column_kwargs(col_cls, si_name, df[si_name].to_numpy(), qm_params)
+        columns.append(col_cls(**col_kwargs))
+        typed_column_names.add(si_name)
+
+    # The remaining quality_metrics DataFrame columns become plain VectorData
+    # on the MetricsRun instance. Column names are preserved so the loader can
+    # reconstruct SI's quality_metrics extension on read.
+    for col_name in df.columns:
+        if col_name in typed_column_names:
+            continue
+        col_values = df[col_name].to_numpy()
+        # Coerce to float for storage; NaNs are preserved.
+        columns.append(
             VectorData(
-                name="start_time", data=start_times, description="Start time of each valid period in seconds."
-            ),
-            VectorData(
-                name="stop_time", data=stop_times, description="Stop time of each valid period in seconds."
-            ),
-            vup_unit_column,
-        ],
+                name=col_name,
+                data=col_values.astype(float),
+                description=f"Run-dependent metric: {col_name}.",
+            )
+        )
+
+    # If valid_unit_periods is computed, store the per-unit windows as
+    # valid_intervals on this MetricsRun instance. valid_intervals is ragged by row
+    # (one row per unit), each cell holds the list of (start, stop) windows
+    # used to restrict that unit's metric computation.
+    vup_ext = sorting_analyzer.get_extension("valid_unit_periods")
+    if vup_ext is not None:
+        if sorting_analyzer.get_num_segments() > 1:
+            raise NotImplementedError(
+                "valid_unit_periods round-trip is single-segment only; "
+                "multi-segment support not yet implemented."
+            )
+        sampling_frequency = sorting_analyzer.sampling_frequency
+        valid_periods_data = vup_ext.get_data(outputs="numpy")
+        per_unit_windows: list[list[tuple[float, float]]] = [[] for _ in range(n_units)]
+        for period in valid_periods_data:
+            unit_idx = int(period["unit_index"])
+            start_s = float(period["start_sample_index"]) / sampling_frequency
+            stop_s = float(period["end_sample_index"]) / sampling_frequency
+            per_unit_windows[unit_idx].append((start_s, stop_s))
+
+        flat_intervals: list[list[float]] = []
+        cumulative = []
+        running = 0
+        for windows in per_unit_windows:
+            for start_s, stop_s in windows:
+                flat_intervals.append([start_s, stop_s])
+            running += len(windows)
+            cumulative.append(running)
+
+        valid_intervals_vd = VectorData(
+            name="valid_intervals",
+            data=np.array(flat_intervals, dtype=np.float64) if flat_intervals else np.zeros((0, 2)),
+            description="Per-unit observation intervals (start, stop) in seconds.",
+        )
+        valid_intervals_index = VectorIndex(
+            name="valid_intervals_index",
+            data=np.array(cumulative, dtype=np.int64),
+            target=valid_intervals_vd,
+        )
+        columns.append(valid_intervals_vd)
+        columns.append(valid_intervals_index)
+
+    return MetricsRun(
+        name="quality_metrics",
+        description="Run-dependent per-unit metrics from one analysis run.",
+        columns=columns,
+    )
+
+
+def _build_column_kwargs(
+    col_cls: type,
+    si_name: str,
+    data: np.ndarray,
+    qm_params: dict,
+) -> dict:
+    """Assemble constructor kwargs for a typed canonical run-dependent column.
+
+    Currently a stub: v1 does not commit any run-dependent typed columns, so
+    this is unused. It is kept as the place where attribute-extraction logic
+    will live when typed run-dependent columns are added in a future version
+    (e.g. pulling SI's ``isi_threshold_ms`` onto a future
+    ``IsiViolationsRatio.refractory_period_ms`` attribute).
+    """
+    return dict(
+        name=si_name,
+        description=col_cls.__doc__ or si_name,
+        data=data,
     )
 
 
@@ -515,20 +678,34 @@ def _convert_all_extensions(sorting_analyzer, nwbfile):  # noqa: C901
         if "waveforms" not in converted:
             raise ValueError("PCA projections require waveforms to be computed.")
         converted.update(_convert_pca(sorting_analyzer, nwbfile, converted["waveforms"]))
-    if _has("valid_unit_periods"):
-        converted["valid_unit_periods"] = _convert_valid_unit_periods(
-            sorting_analyzer, "valid_unit_periods", ValidUnitPeriods, nwbfile.units
-        )
+
+    # Run-dependent metrics flow into a MetricsRun instance (or several, as
+    # support for multiple curation runs is added). For v1 there is one
+    # MetricsRun per file, sourced from SI's quality_metrics extension.
+    metrics_run = _convert_metrics_run(sorting_analyzer, nwbfile)
+    if metrics_run is not None:
+        converted["__metrics_run__"] = metrics_run
 
     return converted
 
 
 def _build_extensions(sorting_analyzer, nwbfile):
-    """Convert extensions and assemble a SpikeSortingExtensions object."""
+    """Convert extensions and assemble a SpikeSortingExtensions object.
+
+    Cell-intrinsic metric columns are added directly to ``nwbfile.units``
+    (a side effect) rather than to the extensions container, because they
+    are per-unit properties of the cells themselves.
+    """
+    # Side effect: write cell-intrinsic metric columns onto nwbfile.units.
+    _add_cell_intrinsic_columns_to_units(sorting_analyzer, nwbfile)
+
     converted = _convert_all_extensions(sorting_analyzer, nwbfile)
     extensions = SpikeSortingExtensions(name="extensions")
     for attr, obj in converted.items():
-        setattr(extensions, attr, obj)
+        if attr == "__metrics_run__":
+            extensions.add_metrics_runs(obj)
+        else:
+            setattr(extensions, attr, obj)
     return extensions
 
 
@@ -735,7 +912,13 @@ def read_sorting_analyzer_from_nwb(
             _load_amplitude_scalings(extensions, sorting_analyzer)
             _load_spike_locations(extensions, sorting_analyzer)
             _load_pca_projections(extensions, sorting_analyzer)
-            _load_valid_unit_periods_from_nwb(extensions, sorting_analyzer)
+            _load_metrics_runs(extensions, sorting_analyzer)
+
+        # Cell-intrinsic metrics live on nwbfile.units as typed columns; read
+        # them by column type so the SI extension binding survives even if a
+        # column was renamed.
+        if nwbfile.units is not None:
+            _load_cell_intrinsic_from_units(nwbfile.units, sorting_analyzer)
 
     return sorting_analyzer
 
@@ -1022,48 +1205,159 @@ def _load_amplitude_scalings(extensions, sorting_analyzer: "SortingAnalyzer") ->
     sorting_analyzer.extensions["amplitude_scalings"] = ext
 
 
-def _load_valid_unit_periods_from_nwb(extensions, sorting_analyzer):
-    """Instantiate the valid_unit_periods extension if present in the NWB container.
+def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnalyzer") -> None:
+    """Read canonical cell-intrinsic typed columns from a Units table.
 
-    **NWB** stores valid unit periods as a ``TimeIntervals`` table with columns:
-    - ``start_time``: start of each valid period in seconds
-    - ``stop_time``: end of each valid period in seconds
-    - ``unit``: DynamicTableRegion referencing the units table
+    Walks the Units table columns, finds those that are instances of canonical
+    typed VectorData classes, and populates the corresponding SI extension
+    DataFrames. Routes by column class via ``CELL_INTRINSIC_COLUMNS``.
 
-    **SpikeInterface** stores valid unit periods as a structured numpy array
-    with dtype ``unit_period_dtype``:
-    ``(segment_index, start_sample_index, end_sample_index, unit_index)``
-    in sample indices.
-
-    The conversion multiplies times by sampling frequency to get sample indices.
-    Since NWB TimeIntervals does not store segment_index, we assume segment 0.
+    When a target SI extension was already populated by ``_load_metrics_runs``
+    (e.g. quality_metrics receives both ``Snr`` from a MetricsRun and
+    ``AmplitudeMedian`` from a Units column), this function merges into the
+    existing DataFrame rather than overwriting it.
     """
+    import pandas as pd
+    from spikeinterface.core.sortinganalyzer import get_extension_class
+
+    per_extension_columns: dict[str, dict[str, np.ndarray]] = {}
+    for col_name in units_table.colnames:
+        col = units_table[col_name]
+        for col_cls, (si_name, si_ext_name) in CELL_INTRINSIC_COLUMNS.items():
+            if isinstance(col, col_cls):
+                per_extension_columns.setdefault(si_ext_name, {})[si_name] = np.asarray(col.data[:])
+                break
+
+    for si_ext_name, columns_dict in per_extension_columns.items():
+        existing = sorting_analyzer.extensions.get(si_ext_name)
+        if existing is not None:
+            # Merge into existing DataFrame; preserve any params/metric_names set
+            # by the prior loader (typically _load_metrics_runs for quality_metrics).
+            existing_df = existing.data.get("metrics")
+            if existing_df is not None:
+                for col_name, values in columns_dict.items():
+                    existing_df[col_name] = values
+                existing.params.setdefault("metric_names", []).extend(
+                    [n for n in columns_dict if n not in existing.params["metric_names"]]
+                )
+                existing.params["metrics_to_compute"] = list(existing.params["metric_names"])
+                continue
+
+        ext_class = get_extension_class(si_ext_name)
+        if ext_class is None:
+            continue
+        unit_ids = sorting_analyzer.unit_ids
+        metrics_df = pd.DataFrame(columns_dict, index=unit_ids)
+        ext = ext_class(sorting_analyzer)
+        ext.params = {
+            "metric_names": list(columns_dict.keys()),
+            "metric_params": {},
+            "metrics_to_compute": list(columns_dict.keys()),
+            "delete_existing_metrics": False,
+        }
+        ext.data["metrics"] = metrics_df
+        ext.run_info = {"run_completed": True, "runtime_s": 0.0}
+        sorting_analyzer.extensions[si_ext_name] = ext
+
+
+def _load_metrics_runs(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
+    """Read MetricsRun instances and reconstruct SI's ``quality_metrics`` and
+    ``valid_unit_periods`` extensions.
+
+    Each MetricsRun is a curation run; its typed columns populate
+    ``quality_metrics``, and its ``valid_intervals`` (if present) populate
+    ``valid_unit_periods``. For v1 we expect at most one MetricsRun per file
+    and route it directly. Multi-run support (each run distinguished by name
+    or parameter context) is a follow-up.
+    """
+    import pandas as pd
     from spikeinterface.core.base import unit_period_dtype
     from spikeinterface.core.sortinganalyzer import get_extension_class
 
-    valid_periods_nwb = getattr(extensions, "valid_unit_periods", None)
-    if valid_periods_nwb is None:
+    metrics_runs = getattr(extensions, "metrics_runs", None)
+    if not metrics_runs:
         return
 
-    start_times = np.array(valid_periods_nwb["start_time"][:], dtype=np.float64)
-    stop_times = np.array(valid_periods_nwb["stop_time"][:], dtype=np.float64)
-    unit_indices = np.array(valid_periods_nwb["unit"].data[:], dtype=np.int64)
+    # Iterate over MetricsRun instances (LabelledDict keyed by name)
+    runs = metrics_runs.values() if hasattr(metrics_runs, "values") else [metrics_runs]
+    for nwb_table in runs:
+        unit_ids = sorting_analyzer.unit_ids
+        per_extension_columns: dict[str, dict[str, np.ndarray]] = {}
+        per_extension_params: dict[str, dict] = {}
 
-    sampling_frequency = sorting_analyzer.sampling_frequency
-    n_periods = len(start_times)
+        for col_name in nwb_table.colnames:
+            if col_name in ("unit", "valid_intervals", "valid_intervals_index"):
+                continue
+            col = nwb_table[col_name]
+            # First try the typed-column registry (empty in v1; kept for forward
+            # compatibility when run-dependent typed columns are added).
+            matched = False
+            for col_cls, (si_name, si_ext_name) in RUN_DEPENDENT_COLUMNS.items():
+                if isinstance(col, col_cls):
+                    per_extension_columns.setdefault(si_ext_name, {})[si_name] = np.asarray(col.data[:])
+                    matched = True
+                    break
+            if matched:
+                continue
+            # Fallback: plain VectorData column. Route to quality_metrics by
+            # convention, using the column name as the SI metric name.
+            per_extension_columns.setdefault("quality_metrics", {})[col_name] = np.asarray(col.data[:])
 
-    valid_periods = np.zeros(n_periods, dtype=unit_period_dtype)
-    valid_periods["segment_index"] = 0
-    valid_periods["start_sample_index"] = np.round(start_times * sampling_frequency).astype(np.int64)
-    valid_periods["end_sample_index"] = np.round(stop_times * sampling_frequency).astype(np.int64)
-    valid_periods["unit_index"] = unit_indices
+        for si_ext_name, columns_dict in per_extension_columns.items():
+            ext_class = get_extension_class(si_ext_name)
+            if ext_class is None:
+                continue
+            metrics_df = pd.DataFrame(columns_dict, index=unit_ids)
+            params = per_extension_params.get(si_ext_name, {})
+            ext = ext_class(sorting_analyzer)
+            ext.params = {
+                "metric_names": list(columns_dict.keys()),
+                "metric_params": params.get("metric_params", {}),
+                "metrics_to_compute": list(columns_dict.keys()),
+                "delete_existing_metrics": False,
+            }
+            ext.data["metrics"] = metrics_df
+            ext.run_info = {"run_completed": True, "runtime_s": 0.0}
+            sorting_analyzer.extensions[si_ext_name] = ext
 
-    ext_class = get_extension_class("valid_unit_periods")
-    ext = ext_class(sorting_analyzer)
-    ext.set_params(method="user_defined", user_defined_periods=valid_periods, minimum_valid_period_duration=0)
-    ext.data["valid_unit_periods"] = valid_periods
-    ext.run_info = {"run_completed": True, "runtime_s": 0.0}
-    sorting_analyzer.extensions["valid_unit_periods"] = ext
+        # Reconstruct valid_unit_periods from valid_intervals if present.
+        if "valid_intervals" in nwb_table.colnames:
+            # nwb_table["valid_intervals"] returns the VectorIndex (the
+            # per-row cumulative boundaries); its .target is the underlying
+            # VectorData with the flat (total_intervals, 2) array.
+            valid_intervals_vi = nwb_table["valid_intervals"]
+            cum = np.asarray(valid_intervals_vi.data[:])
+            flat = np.asarray(valid_intervals_vi.target.data[:])
+            sampling_frequency = sorting_analyzer.sampling_frequency
+
+            periods_list = []
+            prev = 0
+            for unit_idx, end in enumerate(cum):
+                for row in flat[prev:end]:
+                    start_s, stop_s = float(row[0]), float(row[1])
+                    periods_list.append(
+                        (
+                            0,
+                            int(round(start_s * sampling_frequency)),
+                            int(round(stop_s * sampling_frequency)),
+                            unit_idx,
+                        )
+                    )
+                prev = int(end)
+
+            if periods_list:
+                vup_array = np.array(periods_list, dtype=unit_period_dtype)
+                vup_class = get_extension_class("valid_unit_periods")
+                if vup_class is not None:
+                    vup_ext = vup_class(sorting_analyzer)
+                    vup_ext.set_params(
+                        method="user_defined",
+                        user_defined_periods=vup_array,
+                        minimum_valid_period_duration=0,
+                    )
+                    vup_ext.data["valid_unit_periods"] = vup_array
+                    vup_ext.run_info = {"run_completed": True, "runtime_s": 0.0}
+                    sorting_analyzer.extensions["valid_unit_periods"] = vup_ext
 
 
 def _load_pca_projections(extensions, sorting_analyzer: "SortingAnalyzer") -> None:

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -28,32 +28,22 @@ from ndx_spikesorting import (
     PCAProjectionsConcatenated,
     FiringRate,
     UnitMetrics,
+    ValidUnitPeriods,
     SpikeSortingExtensions,
     SpikeSortingContainer,
 )
 
-# ---------------------------------------------------------------------------
-# Canonical column registry
-# ---------------------------------------------------------------------------
-# Maps each typed VectorData column class to:
-#   - the SI metric column name it represents (the DataFrame column key)
-#   - the SI extension name it should be routed to on read
-#   - which side of the cell-vs-algorithm split it lives on
-#
-# This mapping is the single point of SI knowledge in the loader; the spec
-# itself stays tool-agnostic.
+# Registries mapping canonical typed VectorData classes to
+# (si_metric_name, si_extension_name). The writer uses col_cls=<class> when
+# adding a column whose class appears here; other columns are written as plain
+# VectorData with the name preserved. The registries are the single point of
+# SpikeInterface-specific knowledge in the loader; the spec stays tool-agnostic.
 
-# Mapping from canonical typed column class -> (si_metric_name, si_extension_name).
-# The writer routes SI's DataFrame columns to typed columns when the class is
-# registered here; otherwise the column is written as plain VectorData.
-CELL_INTRINSIC_COLUMNS = {
+UNITS_TYPED_COLUMNS = {
     FiringRate: ("firing_rate", "spiketrain_metrics"),
 }
 
-# No typed column classes are registered yet for the run-dependent side;
-# run-dependent metrics flow as plain VectorData columns onto UnitMetrics
-# instances. The registry is kept for forward compatibility.
-RUN_DEPENDENT_COLUMNS: dict = {}
+UNIT_METRICS_TYPED_COLUMNS: dict = {}
 
 
 def templates_to_dense(templates: Templates, num_channels: int) -> np.ndarray:
@@ -351,7 +341,7 @@ def _add_cell_intrinsic_columns_to_units(
 
     # Cache SI extension DataFrames by name so we only pull each once.
     si_extension_data: dict[str, "pd.DataFrame"] = {}
-    for col_cls, (si_name, si_ext_name) in CELL_INTRINSIC_COLUMNS.items():
+    for col_cls, (si_name, si_ext_name) in UNITS_TYPED_COLUMNS.items():
         if si_ext_name not in si_extension_data:
             ext = sorting_analyzer.get_extension(si_ext_name)
             si_extension_data[si_ext_name] = ext.get_data() if ext is not None else None
@@ -377,7 +367,7 @@ def _convert_unit_metrics(
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
     as typed columns. If ``valid_unit_periods`` is also computed, the per-unit
-    valid windows are written as ``valid_intervals`` on the table. Returns
+    valid windows are written as ``obs_intervals`` on the table. Returns
     ``None`` when ``quality_metrics`` is not computed.
     """
     qm_ext = sorting_analyzer.get_extension("quality_metrics")
@@ -403,7 +393,7 @@ def _convert_unit_metrics(
     # empty (no run-dependent typed columns committed in v1), but keeps the
     # design open for adding typed columns in a later version.
     typed_column_names: set[str] = set()
-    for col_cls, (si_name, _) in RUN_DEPENDENT_COLUMNS.items():
+    for col_cls, (si_name, _) in UNIT_METRICS_TYPED_COLUMNS.items():
         if si_name not in df.columns:
             continue
         col_kwargs = _build_column_kwargs(col_cls, si_name, df[si_name].to_numpy(), qm_params)
@@ -427,7 +417,7 @@ def _convert_unit_metrics(
         )
 
     # If valid_unit_periods is computed, store the per-unit windows as
-    # valid_intervals on this UnitMetrics instance. valid_intervals is ragged by row
+    # obs_intervals on this UnitMetrics instance. obs_intervals is ragged by row
     # (one row per unit), each cell holds the list of (start, stop) windows
     # used to restrict that unit's metric computation.
     vup_ext = sorting_analyzer.get_extension("valid_unit_periods")
@@ -455,18 +445,18 @@ def _convert_unit_metrics(
             running += len(windows)
             cumulative.append(running)
 
-        valid_intervals_vd = VectorData(
-            name="valid_intervals",
+        obs_intervals_vd = VectorData(
+            name="obs_intervals",
             data=np.array(flat_intervals, dtype=np.float64) if flat_intervals else np.zeros((0, 2)),
             description="Per-unit observation intervals (start, stop) in seconds.",
         )
-        valid_intervals_index = VectorIndex(
-            name="valid_intervals_index",
+        obs_intervals_index = VectorIndex(
+            name="obs_intervals_index",
             data=np.array(cumulative, dtype=np.int64),
-            target=valid_intervals_vd,
+            target=obs_intervals_vd,
         )
-        columns.append(valid_intervals_vd)
-        columns.append(valid_intervals_index)
+        columns.append(obs_intervals_vd)
+        columns.append(obs_intervals_index)
 
     return UnitMetrics(
         name="quality_metrics",
@@ -1203,7 +1193,7 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
 
     Walks the Units table columns, finds those that are instances of canonical
     typed VectorData classes, and populates the corresponding SI extension
-    DataFrames. Routes by column class via ``CELL_INTRINSIC_COLUMNS``.
+    DataFrames. Routes by column class via ``UNITS_TYPED_COLUMNS``.
 
     When a target SI extension was already populated by ``_load_unit_metrics``
     (e.g. quality_metrics receives both ``Snr`` from a UnitMetrics and
@@ -1216,7 +1206,7 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
     per_extension_columns: dict[str, dict[str, np.ndarray]] = {}
     for col_name in units_table.colnames:
         col = units_table[col_name]
-        for col_cls, (si_name, si_ext_name) in CELL_INTRINSIC_COLUMNS.items():
+        for col_cls, (si_name, si_ext_name) in UNITS_TYPED_COLUMNS.items():
             if isinstance(col, col_cls):
                 per_extension_columns.setdefault(si_ext_name, {})[si_name] = np.asarray(col.data[:])
                 break
@@ -1258,7 +1248,7 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
     ``valid_unit_periods`` extensions.
 
     Each UnitMetrics is a curation run; its typed columns populate
-    ``quality_metrics``, and its ``valid_intervals`` (if present) populate
+    ``quality_metrics``, and its ``obs_intervals`` (if present) populate
     ``valid_unit_periods``. For v1 we expect at most one UnitMetrics per file
     and route it directly. Multi-run support (each run distinguished by name
     or parameter context) is a follow-up.
@@ -1279,13 +1269,13 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
         per_extension_params: dict[str, dict] = {}
 
         for col_name in nwb_table.colnames:
-            if col_name in ("unit", "valid_intervals", "valid_intervals_index"):
+            if col_name in ("unit", "obs_intervals", "obs_intervals_index"):
                 continue
             col = nwb_table[col_name]
             # First try the typed-column registry (empty in v1; kept for forward
             # compatibility when run-dependent typed columns are added).
             matched = False
-            for col_cls, (si_name, si_ext_name) in RUN_DEPENDENT_COLUMNS.items():
+            for col_cls, (si_name, si_ext_name) in UNIT_METRICS_TYPED_COLUMNS.items():
                 if isinstance(col, col_cls):
                     per_extension_columns.setdefault(si_ext_name, {})[si_name] = np.asarray(col.data[:])
                     matched = True
@@ -1313,14 +1303,14 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
             ext.run_info = {"run_completed": True, "runtime_s": 0.0}
             sorting_analyzer.extensions[si_ext_name] = ext
 
-        # Reconstruct valid_unit_periods from valid_intervals if present.
-        if "valid_intervals" in nwb_table.colnames:
-            # nwb_table["valid_intervals"] returns the VectorIndex (the
+        # Reconstruct valid_unit_periods from obs_intervals if present.
+        if "obs_intervals" in nwb_table.colnames:
+            # nwb_table["obs_intervals"] returns the VectorIndex (the
             # per-row cumulative boundaries); its .target is the underlying
             # VectorData with the flat (total_intervals, 2) array.
-            valid_intervals_vi = nwb_table["valid_intervals"]
-            cum = np.asarray(valid_intervals_vi.data[:])
-            flat = np.asarray(valid_intervals_vi.target.data[:])
+            obs_intervals_vi = nwb_table["obs_intervals"]
+            cum = np.asarray(obs_intervals_vi.data[:])
+            flat = np.asarray(obs_intervals_vi.target.data[:])
             sampling_frequency = sorting_analyzer.sampling_frequency
 
             periods_list = []

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -46,6 +46,80 @@ UNITS_TYPED_COLUMNS = {
 
 UNIT_METRICS_TYPED_COLUMNS: dict = {}
 
+# Hard-coded routing of UnitMetrics column names back into SpikeInterface (SI)
+# extension keys for the reader. The NWB file itself does not carry any
+# SI-specific tag on these columns; this dict is the only place where the
+# reader expresses "column X belongs to SI extension Y". Sourced from
+# ``spikeinterface.metrics.get_template_metric_list``,
+# ``get_quality_metric_list``, ``get_spiketrain_metric_list`` as of
+# SpikeInterface 0.104. Update when SI adds a new column. The dict-currency
+# guard test asserts that every column SI produces is covered here.
+#
+# Some columns (``num_spikes``, ``firing_rate``) are produced by multiple
+# SI extensions; we list every target so the reader replicates the column
+# value across each target extension. The reader merges values into existing
+# extension DataFrames when one was already populated by an earlier loader
+# step (typically the typed-column route via UNITS_TYPED_COLUMNS).
+COLUMN_TO_EXTENSION: dict[str, tuple[str, ...]] = {
+    # template_metrics (waveform morphology)
+    "peak_to_trough_duration": ("template_metrics",),
+    "trough_half_width": ("template_metrics",),
+    "peak_half_width": ("template_metrics",),
+    "repolarization_slope": ("template_metrics",),
+    "recovery_slope": ("template_metrics",),
+    "num_positive_peaks": ("template_metrics",),
+    "num_negative_peaks": ("template_metrics",),
+    "main_to_next_extremum_duration": ("template_metrics",),
+    "peak_before_to_trough_ratio": ("template_metrics",),
+    "peak_after_to_trough_ratio": ("template_metrics",),
+    "peak_before_to_peak_after_ratio": ("template_metrics",),
+    "main_peak_to_trough_ratio": ("template_metrics",),
+    "trough_width": ("template_metrics",),
+    "peak_before_width": ("template_metrics",),
+    "peak_after_width": ("template_metrics",),
+    "waveform_baseline_flatness": ("template_metrics",),
+    "velocity_above": ("template_metrics",),
+    "velocity_below": ("template_metrics",),
+    "exp_decay": ("template_metrics",),
+    "spread": ("template_metrics",),
+    # quality_metrics (sorting-run-dependent quality)
+    "presence_ratio": ("quality_metrics",),
+    "isi_violations_ratio": ("quality_metrics",),
+    "isi_violations_count": ("quality_metrics",),
+    "rp_contamination": ("quality_metrics",),
+    "rp_violations": ("quality_metrics",),
+    "sliding_rp_violation": ("quality_metrics",),
+    "amplitude_cutoff": ("quality_metrics",),
+    "noise_cutoff": ("quality_metrics",),
+    "noise_ratio": ("quality_metrics",),
+    "amplitude_median": ("quality_metrics",),
+    "amplitude_cv_median": ("quality_metrics",),
+    "amplitude_cv_range": ("quality_metrics",),
+    "sd_ratio": ("quality_metrics",),
+    "snr": ("quality_metrics",),
+    "isolation_distance": ("quality_metrics",),
+    "l_ratio": ("quality_metrics",),
+    "d_prime": ("quality_metrics",),
+    "nn_hit_rate": ("quality_metrics",),
+    "nn_miss_rate": ("quality_metrics",),
+    "nn_isolation": ("quality_metrics",),
+    "nn_noise_overlap": ("quality_metrics",),
+    "silhouette": ("quality_metrics",),
+    "silhouette_full": ("quality_metrics",),
+    "silhouette_simplified": ("quality_metrics",),
+    "sync_spike_2": ("quality_metrics",),
+    "sync_spike_4": ("quality_metrics",),
+    "sync_spike_8": ("quality_metrics",),
+    "firing_range": ("quality_metrics",),
+    "drift_ptp": ("quality_metrics",),
+    "drift_std": ("quality_metrics",),
+    "drift_mad": ("quality_metrics",),
+    "peak_channel": ("quality_metrics",),
+    # Aliased columns: produced by both quality_metrics and spiketrain_metrics
+    "num_spikes": ("quality_metrics", "spiketrain_metrics"),
+    "firing_rate": ("quality_metrics", "spiketrain_metrics"),
+}
+
 
 def templates_to_dense(templates: Templates, num_channels: int) -> np.ndarray:
     """Convert sparse ragged templates to a dense 3D array.
@@ -372,12 +446,33 @@ def _convert_unit_metrics(
     Returns ``None`` when ``quality_metrics`` is not computed.
     """
     qm_ext = sorting_analyzer.get_extension("quality_metrics")
-    if qm_ext is None:
+    tm_ext = sorting_analyzer.get_extension("template_metrics")
+    if qm_ext is None and tm_ext is None:
         return None
 
-    df = qm_ext.get_data()
+    # Combine quality_metrics and template_metrics columns into a single
+    # DataFrame. Each column will become a VectorData entry on the UnitMetrics
+    # table; on read, the loader uses COLUMN_TO_EXTENSION to route each column
+    # back to the right SI extension. We do not pull from spiketrain_metrics
+    # separately because its columns (num_spikes, firing_rate) are aliases of
+    # quality_metrics columns and already pulled via qm_ext.
+    if qm_ext is not None and tm_ext is not None:
+        qm_df = qm_ext.get_data()
+        tm_df = tm_ext.get_data()
+        overlap = set(qm_df.columns) & set(tm_df.columns)
+        if overlap:
+            # In SI 0.104 quality_metrics and template_metrics do not overlap.
+            # Guard for future versions: if a column appears in both, prefer
+            # the quality_metrics value (arbitrary but deterministic).
+            tm_df = tm_df.drop(columns=list(overlap))
+        df = qm_df.join(tm_df)
+    elif qm_ext is not None:
+        df = qm_ext.get_data()
+    else:
+        df = tm_ext.get_data()
+
     n_units = len(sorting_analyzer.unit_ids)
-    qm_params = qm_ext.params or {}
+    qm_params = qm_ext.params or {} if qm_ext is not None else {}
 
     # Per-row unit DTR pointing back to nwbfile.units (one row per unit).
     unit_column = DynamicTableRegion(
@@ -1290,13 +1385,18 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
 
 
 def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
-    """Read UnitMetrics instances and reconstruct SI's ``quality_metrics`` extension.
+    """Read UnitMetrics instances and reconstruct the relevant SI extensions.
 
-    Each UnitMetrics is a curation run whose typed (and plain) columns populate
-    ``quality_metrics``. For v1 we expect at most one UnitMetrics per file and
-    route it directly. Multi-run support (each run distinguished by name or
-    parameter context) is a follow-up.
+    Each UnitMetrics row holds one unit's metric values; column names identify
+    the metric. The loader routes each column to the SI extension it belongs to
+    using ``COLUMN_TO_EXTENSION``. A column listed under multiple extensions
+    (e.g., ``num_spikes`` belongs to both ``quality_metrics`` and
+    ``spiketrain_metrics``) is replicated into each target. A column not in the
+    dict falls back to ``quality_metrics`` (matching pre-fix behavior) and is
+    surfaced via a warning so the dict can be kept in sync with SI's registries.
     """
+    import warnings
+
     import pandas as pd
     from spikeinterface.core.sortinganalyzer import get_extension_class
 
@@ -1325,13 +1425,38 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
                     break
             if matched:
                 continue
-            # Fallback: plain VectorData column. Route to quality_metrics by
-            # convention, using the column name as the SI metric name.
-            per_extension_columns.setdefault("quality_metrics", {})[col_name] = np.asarray(col.data[:])
+            # Route plain VectorData columns by name via COLUMN_TO_EXTENSION.
+            # Replicate into every target extension when the column belongs to
+            # more than one (the SI extension-aliasing case).
+            targets = COLUMN_TO_EXTENSION.get(col_name)
+            if targets is None:
+                warnings.warn(
+                    f"Column {col_name!r} on UnitMetrics is not in "
+                    "COLUMN_TO_EXTENSION; routing to quality_metrics by default. "
+                    "Update the dict in utils.py to silence this warning.",
+                    stacklevel=2,
+                )
+                targets = ("quality_metrics",)
+            values = np.asarray(col.data[:])
+            for si_ext_name in targets:
+                per_extension_columns.setdefault(si_ext_name, {})[col_name] = values
 
         for si_ext_name, columns_dict in per_extension_columns.items():
             ext_class = get_extension_class(si_ext_name)
             if ext_class is None:
+                continue
+            existing = sorting_analyzer.extensions.get(si_ext_name)
+            if existing is not None and existing.data.get("metrics") is not None:
+                # Merge into an extension already populated by an earlier loader
+                # step. Preserve existing metric_names; append new ones.
+                existing_df = existing.data["metrics"]
+                for col_name_inner, values in columns_dict.items():
+                    existing_df[col_name_inner] = values
+                metric_names = existing.params.setdefault("metric_names", [])
+                for n in columns_dict:
+                    if n not in metric_names:
+                        metric_names.append(n)
+                existing.params["metrics_to_compute"] = list(metric_names)
                 continue
             metrics_df = pd.DataFrame(columns_dict, index=unit_ids)
             params = per_extension_params.get(si_ext_name, {})

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -29,7 +29,7 @@ from ndx_spikesorting import (
     PCAProjectionsConcatenated,
     FiringRate,
     MetricVectorData,
-    UnitMetrics,
+    UnitsMetrics,
     ValidUnitPeriods,
     SpikeSortingExtensions,
     SpikeSortingContainer,
@@ -45,9 +45,9 @@ UNITS_TYPED_COLUMNS = {
     FiringRate: ("firing_rate", "spiketrain_metrics"),
 }
 
-UNIT_METRICS_TYPED_COLUMNS: dict = {}
+UNITS_METRICS_TYPED_COLUMNS: dict = {}
 
-# Hard-coded routing of UnitMetrics column names back into SpikeInterface (SI)
+# Hard-coded routing of UnitsMetrics column names back into SpikeInterface (SI)
 # extension keys for the reader. The NWB file itself does not carry any
 # SI-specific tag on these columns; this dict is the only place where the
 # reader expresses "column X belongs to SI extension Y". Sourced from
@@ -453,7 +453,7 @@ def _analyzer_positions_to_units_rows(sorting_analyzer, units_table) -> list[int
 
     Raises ValueError if an analyzer unit id has no matching row in the units
     table. This is what makes the writer order-independent: the resulting list,
-    used as DTR data, points each row of UnitMetrics at the right nwbfile.units
+    used as DTR data, points each row of UnitsMetrics at the right nwbfile.units
     row regardless of whether the two tables share an ordering.
     """
     id_lookup = _units_table_id_lookup(units_table)
@@ -467,12 +467,12 @@ def _analyzer_positions_to_units_rows(sorting_analyzer, units_table) -> list[int
     return [id_lookup[uid] for uid in analyzer_ids]
 
 
-def _convert_unit_metrics(
+def _convert_units_metrics(
     sorting_analyzer: "SortingAnalyzer",
     nwbfile: NWBFile,
     time_support_ref: "ValidUnitPeriods | None" = None,
-) -> UnitMetrics | None:
-    """Build a UnitMetrics instance from SI's ``quality_metrics`` extension.
+) -> UnitsMetrics | None:
+    """Build a UnitsMetrics instance from SI's ``quality_metrics`` extension.
 
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
@@ -488,7 +488,7 @@ def _convert_unit_metrics(
         return None
 
     # Combine quality_metrics and template_metrics columns into a single
-    # DataFrame. Each column will become a VectorData entry on the UnitMetrics
+    # DataFrame. Each column will become a VectorData entry on the UnitsMetrics
     # table; on read, the loader uses COLUMN_TO_EXTENSION to route each column
     # back to the right SI extension. We do not pull from spiketrain_metrics
     # separately because its columns (num_spikes, firing_rate) are aliases of
@@ -536,7 +536,7 @@ def _convert_unit_metrics(
             col_kwargs["time_support"] = time_support_ref
         columns.append(MetricVectorData(**col_kwargs))
 
-    return UnitMetrics(
+    return UnitsMetrics(
         name="quality_metrics",
         description="Run-dependent per-unit metrics from one analysis run.",
         columns=columns,
@@ -800,19 +800,19 @@ def _convert_all_extensions(sorting_analyzer, nwbfile):  # noqa: C901
 
     # Build ValidUnitPeriods first (preferring quality_metrics.params["periods"]
     # when set, since that's what the metric columns are actually constrained
-    # by). UnitMetrics columns reference this table via their time_support
+    # by). UnitsMetrics columns reference this table via their time_support
     # attribute, so the intervals are stored once and pointed to by every
     # column they apply to.
     vup = _build_valid_unit_periods(sorting_analyzer, units_table=nwbfile.units)
     if vup is not None:
         converted["valid_unit_periods"] = vup
 
-    # Run-dependent metrics flow into a UnitMetrics instance (or several, as
+    # Run-dependent metrics flow into a UnitsMetrics instance (or several, as
     # support for multiple curation runs is added). For v1 there is one
-    # UnitMetrics per file, sourced from SI's quality_metrics extension.
-    unit_metrics = _convert_unit_metrics(sorting_analyzer, nwbfile, time_support_ref=vup)
-    if unit_metrics is not None:
-        converted["__unit_metrics__"] = unit_metrics
+    # UnitsMetrics per file, sourced from SI's quality_metrics extension.
+    units_metrics = _convert_units_metrics(sorting_analyzer, nwbfile, time_support_ref=vup)
+    if units_metrics is not None:
+        converted["__units_metrics__"] = units_metrics
 
     return converted
 
@@ -830,8 +830,8 @@ def _build_extensions(sorting_analyzer, nwbfile):
     converted = _convert_all_extensions(sorting_analyzer, nwbfile)
     extensions = SpikeSortingExtensions(name="extensions")
     for attr, obj in converted.items():
-        if attr == "__unit_metrics__":
-            extensions.add_unit_metrics(obj)
+        if attr == "__units_metrics__":
+            extensions.add_units_metrics(obj)
         else:
             setattr(extensions, attr, obj)
     return extensions
@@ -1040,7 +1040,7 @@ def read_sorting_analyzer_from_nwb(
             _load_amplitude_scalings(extensions, sorting_analyzer)
             _load_spike_locations(extensions, sorting_analyzer)
             _load_pca_projections(extensions, sorting_analyzer)
-            _load_unit_metrics(extensions, sorting_analyzer)
+            _load_units_metrics(extensions, sorting_analyzer)
             _load_valid_unit_periods_from_nwb(extensions, sorting_analyzer)
 
         # Cell-intrinsic metrics live on nwbfile.units as typed columns; read
@@ -1341,8 +1341,8 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
     typed VectorData classes, and populates the corresponding SI extension
     DataFrames. Routes by column class via ``UNITS_TYPED_COLUMNS``.
 
-    When a target SI extension was already populated by ``_load_unit_metrics``
-    (e.g. quality_metrics receives both ``Snr`` from a UnitMetrics and
+    When a target SI extension was already populated by ``_load_units_metrics``
+    (e.g. quality_metrics receives both ``Snr`` from a UnitsMetrics and
     ``AmplitudeMedian`` from a Units column), this function merges into the
     existing DataFrame rather than overwriting it.
     """
@@ -1361,7 +1361,7 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
         existing = sorting_analyzer.extensions.get(si_ext_name)
         if existing is not None:
             # Merge into existing DataFrame; preserve any params/metric_names set
-            # by the prior loader (typically _load_unit_metrics for quality_metrics).
+            # by the prior loader (typically _load_units_metrics for quality_metrics).
             existing_df = existing.data.get("metrics")
             if existing_df is not None:
                 for col_name, values in columns_dict.items():
@@ -1389,8 +1389,8 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
         sorting_analyzer.extensions[si_ext_name] = ext
 
 
-def _collect_unit_metrics_columns(nwb_table, sorting_analyzer):
-    """Walk a UnitMetrics table once and return (per_extension_columns, time_support_link).
+def _collect_units_metrics_columns(nwb_table, sorting_analyzer):
+    """Walk a UnitsMetrics table once and return (per_extension_columns, time_support_link).
 
     Reorders each column's row values into analyzer-unit-position order using
     the DTR-resolved row → analyzer position map, so the resulting arrays are
@@ -1400,7 +1400,7 @@ def _collect_unit_metrics_columns(nwb_table, sorting_analyzer):
     import warnings
 
     row_to_analyzer_pos = _dtr_rows_to_analyzer_positions(nwb_table["unit"], sorting_analyzer)
-    # Permutation that places UnitMetrics row i's value at the slot corresponding
+    # Permutation that places UnitsMetrics row i's value at the slot corresponding
     # to its analyzer unit position in the output array.
     reorder = np.argsort(row_to_analyzer_pos)
 
@@ -1414,7 +1414,7 @@ def _collect_unit_metrics_columns(nwb_table, sorting_analyzer):
             time_support_link = getattr(col, "time_support", None)
         # Typed-column registry path (empty in v1; future-proofing).
         matched = False
-        for col_cls, (si_name, si_ext_name) in UNIT_METRICS_TYPED_COLUMNS.items():
+        for col_cls, (si_name, si_ext_name) in UNITS_METRICS_TYPED_COLUMNS.items():
             if isinstance(col, col_cls):
                 raw = np.asarray(col.data[:])
                 per_extension_columns.setdefault(si_ext_name, {})[si_name] = raw[reorder]
@@ -1425,7 +1425,7 @@ def _collect_unit_metrics_columns(nwb_table, sorting_analyzer):
         targets = COLUMN_TO_EXTENSION.get(col_name)
         if targets is None:
             warnings.warn(
-                f"Column {col_name!r} on UnitMetrics is not in "
+                f"Column {col_name!r} on UnitsMetrics is not in "
                 "COLUMN_TO_EXTENSION; routing to quality_metrics by default. "
                 "Update the dict in utils.py to silence this warning.",
                 stacklevel=2,
@@ -1437,10 +1437,10 @@ def _collect_unit_metrics_columns(nwb_table, sorting_analyzer):
     return per_extension_columns, time_support_link
 
 
-def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
-    """Read UnitMetrics instances and reconstruct the relevant SI extensions.
+def _load_units_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
+    """Read UnitsMetrics instances and reconstruct the relevant SI extensions.
 
-    Each UnitMetrics row holds one unit's metric values; column names identify
+    Each UnitsMetrics row holds one unit's metric values; column names identify
     the metric. The loader routes each column to the SI extension it belongs to
     using ``COLUMN_TO_EXTENSION``. A column listed under multiple extensions
     (e.g., ``num_spikes`` belongs to both ``quality_metrics`` and
@@ -1452,16 +1452,16 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
     from spikeinterface.core.base import unit_period_dtype
     from spikeinterface.core.sortinganalyzer import get_extension_class
 
-    unit_metrics = getattr(extensions, "unit_metrics", None)
-    if not unit_metrics:
+    units_metrics = getattr(extensions, "units_metrics", None)
+    if not units_metrics:
         return
 
-    # Iterate over UnitMetrics instances (LabelledDict keyed by name)
-    runs = unit_metrics.values() if hasattr(unit_metrics, "values") else [unit_metrics]
+    # Iterate over UnitsMetrics instances (LabelledDict keyed by name)
+    runs = units_metrics.values() if hasattr(units_metrics, "values") else [units_metrics]
     for nwb_table in runs:
         unit_ids = sorting_analyzer.unit_ids
         per_extension_params: dict[str, dict] = {}
-        per_extension_columns, time_support_link = _collect_unit_metrics_columns(
+        per_extension_columns, time_support_link = _collect_units_metrics_columns(
             nwb_table, sorting_analyzer
         )
 

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -7,11 +7,11 @@ import numpy as np
 
 from hdmf.common import VectorData, VectorIndex, DynamicTableRegion
 from pynwb import NWBFile
+from pynwb import get_type_map
 from pynwb.ecephys import ElectricalSeries
 from pynwb.epoch import TimeIntervals
 
 if TYPE_CHECKING:
-    import pandas as pd
     from spikeinterface.core import SortingAnalyzer
 
 from ndx_spikesorting import (
@@ -36,90 +36,28 @@ from ndx_spikesorting import (
     SpikeSortingContainer,
 )
 
-# Registries mapping canonical typed VectorData classes to
-# (si_metric_name, si_extension_name). The writer uses col_cls=<class> when
-# adding a column whose class appears here; other columns are written as plain
-# VectorData with the name preserved. The registries are the single point of
-# SpikeInterface-specific knowledge in the loader; the spec stays tool-agnostic.
 
+def find_extension_metric_targets(col_name: str) -> tuple[str, ...]:
+    """Return the SI extension(s) a given metric column belongs to, based on COLUMN_TO_EXTENSION."""
+    from spikeinterface.metrics import ComputeQualityMetrics, ComputeSpikeTrainMetrics, ComputeTemplateMetrics
+
+    extension_targets = ()
+    for potential_target in [
+        ComputeQualityMetrics,
+        ComputeSpikeTrainMetrics,
+        ComputeTemplateMetrics,
+    ]:
+        if col_name in potential_target.get_metric_columns():
+            extension_targets += (potential_target.extension_name,)
+    return extension_targets
+
+# Registries mapping canonical metric names to typed VectorData classes.
+# The writer uses col_cls=<class> when adding a column whose class appears here;
+# other columns are written as plain VectorData with the name preserved. 
+# The registries are the single point of SpikeInterface-specific knowledge in the loader; 
+# the spec stays tool-agnostic.
 UNITS_TYPED_COLUMNS = {
-    FiringRate: ("firing_rate", "spiketrain_metrics"),
-}
-
-UNITS_METRICS_TYPED_COLUMNS: dict = {}
-
-# Hard-coded routing of UnitsMetrics column names back into SpikeInterface (SI)
-# extension keys for the reader. The NWB file itself does not carry any
-# SI-specific tag on these columns; this dict is the only place where the
-# reader expresses "column X belongs to SI extension Y". Sourced from
-# ``spikeinterface.metrics.get_template_metric_list``,
-# ``get_quality_metric_list``, ``get_spiketrain_metric_list`` as of
-# SpikeInterface 0.104. Update when SI adds a new column. The dict-currency
-# guard test asserts that every column SI produces is covered here.
-#
-# Some columns (``num_spikes``, ``firing_rate``) are produced by multiple
-# SI extensions; we list every target so the reader replicates the column
-# value across each target extension. The reader merges values into existing
-# extension DataFrames when one was already populated by an earlier loader
-# step (typically the typed-column route via UNITS_TYPED_COLUMNS).
-COLUMN_TO_EXTENSION: dict[str, tuple[str, ...]] = {
-    # template_metrics (waveform morphology)
-    "peak_to_trough_duration": ("template_metrics",),
-    "trough_half_width": ("template_metrics",),
-    "peak_half_width": ("template_metrics",),
-    "repolarization_slope": ("template_metrics",),
-    "recovery_slope": ("template_metrics",),
-    "num_positive_peaks": ("template_metrics",),
-    "num_negative_peaks": ("template_metrics",),
-    "main_to_next_extremum_duration": ("template_metrics",),
-    "peak_before_to_trough_ratio": ("template_metrics",),
-    "peak_after_to_trough_ratio": ("template_metrics",),
-    "peak_before_to_peak_after_ratio": ("template_metrics",),
-    "main_peak_to_trough_ratio": ("template_metrics",),
-    "trough_width": ("template_metrics",),
-    "peak_before_width": ("template_metrics",),
-    "peak_after_width": ("template_metrics",),
-    "waveform_baseline_flatness": ("template_metrics",),
-    "velocity_above": ("template_metrics",),
-    "velocity_below": ("template_metrics",),
-    "exp_decay": ("template_metrics",),
-    "spread": ("template_metrics",),
-    # quality_metrics (sorting-run-dependent quality)
-    "presence_ratio": ("quality_metrics",),
-    "isi_violations_ratio": ("quality_metrics",),
-    "isi_violations_count": ("quality_metrics",),
-    "rp_contamination": ("quality_metrics",),
-    "rp_violations": ("quality_metrics",),
-    "sliding_rp_violation": ("quality_metrics",),
-    "amplitude_cutoff": ("quality_metrics",),
-    "noise_cutoff": ("quality_metrics",),
-    "noise_ratio": ("quality_metrics",),
-    "amplitude_median": ("quality_metrics",),
-    "amplitude_cv_median": ("quality_metrics",),
-    "amplitude_cv_range": ("quality_metrics",),
-    "sd_ratio": ("quality_metrics",),
-    "snr": ("quality_metrics",),
-    "isolation_distance": ("quality_metrics",),
-    "l_ratio": ("quality_metrics",),
-    "d_prime": ("quality_metrics",),
-    "nn_hit_rate": ("quality_metrics",),
-    "nn_miss_rate": ("quality_metrics",),
-    "nn_isolation": ("quality_metrics",),
-    "nn_noise_overlap": ("quality_metrics",),
-    "silhouette": ("quality_metrics",),
-    "silhouette_full": ("quality_metrics",),
-    "silhouette_simplified": ("quality_metrics",),
-    "sync_spike_2": ("quality_metrics",),
-    "sync_spike_4": ("quality_metrics",),
-    "sync_spike_8": ("quality_metrics",),
-    "firing_range": ("quality_metrics",),
-    "drift_ptp": ("quality_metrics",),
-    "drift_std": ("quality_metrics",),
-    "drift_mad": ("quality_metrics",),
-    "peak_channel": ("quality_metrics",),
-    # Aliased columns: produced by both quality_metrics and spiketrain_metrics
-    "num_spikes": ("quality_metrics", "spiketrain_metrics"),
-    "firing_rate": ("quality_metrics", "spiketrain_metrics"),
+    "firing_rate": FiringRate
 }
 
 
@@ -138,23 +76,13 @@ def _columns_supporting_periods() -> set[str]:
     even when ``qm_ext.params["periods"]`` is set, because the periods didn't
     actually constrain those values.
     """
+    from spikeinterface.metrics import ComputeQualityMetrics, ComputeTemplateMetrics, ComputeSpikeTrainMetrics
     cols: set[str] = set()
-    try:
-        from spikeinterface.metrics.quality.quality_metrics import ComputeQualityMetrics
 
-        for m in ComputeQualityMetrics.metric_list:
+    for metric_ext_cls in [ComputeQualityMetrics, ComputeSpikeTrainMetrics, ComputeTemplateMetrics]:
+        for m in metric_ext_cls.metric_list:
             if getattr(m, "supports_periods", False):
                 cols.update(m.metric_columns.keys())
-    except ImportError:
-        pass
-    try:
-        from spikeinterface.metrics.spiketrain.spiketrain_metrics import ComputeSpikeTrainMetrics
-
-        for m in ComputeSpikeTrainMetrics.metric_list:
-            if getattr(m, "supports_periods", False):
-                cols.update(m.metric_columns.keys())
-    except ImportError:
-        pass
     return cols
 
 
@@ -425,16 +353,17 @@ def _convert_spike_vector_extension(
     return nwb_class(name=extension_name, data=data, data_index=data_index)
 
 
+### METRICS ZONE ###
 def _add_cell_intrinsic_columns_to_units(
     sorting_analyzer: "SortingAnalyzer",
     nwbfile: NWBFile,
 ) -> None:
     """Add canonical cell-intrinsic metric columns to ``nwbfile.units``.
 
-    Pulls per-unit values from SI's ``template_metrics`` and ``spiketrain_metrics``
-    DataFrames and writes them as typed VectorData columns on the existing
-    ``nwbfile.units`` table. Each column carries its type tag (e.g. ``FiringRate``)
-    so a reader can recover the canonical mapping back to SI extensions.
+    Pulls per-unit values from SI's ``metrics`` extension DataFrame and writes them
+    as typed VectorData columns on the existing ``nwbfile.units`` table. Each column
+    carries its type tag (e.g. ``FiringRate``) so a reader can recover the canonical
+    mapping back to SI extensions.
 
     The rows of ``nwbfile.units`` are assumed to be aligned with
     ``sorting_analyzer.unit_ids`` (neuroconv's ``add_sorting_to_nwbfile``
@@ -451,23 +380,23 @@ def _add_cell_intrinsic_columns_to_units(
             "NWB file before calling add_sorting_analyzer_to_nwbfile."
         )
 
-    # Cache SI extension DataFrames by name so we only pull each once.
-    si_extension_data: dict[str, "pd.DataFrame"] = {}
-    for col_cls, (si_name, si_ext_name) in UNITS_TYPED_COLUMNS.items():
-        if si_ext_name not in si_extension_data:
-            ext = sorting_analyzer.get_extension(si_ext_name)
-            si_extension_data[si_ext_name] = ext.get_data() if ext is not None else None
-        df = si_extension_data[si_ext_name]
-        if df is None or si_name not in df.columns:
-            continue
-        if si_name in nwbfile.units.colnames:
-            continue  # already populated
-        nwbfile.units.add_column(
-            name=si_name,
-            description=col_cls.__doc__ or si_name,
-            data=df[si_name].to_numpy(),
-            col_cls=col_cls,
-        )
+    all_metrics = sorting_analyzer.get_metrics_extension_data()
+    # remove dulpicate columns until SI 0.105.0 is released with a bugfix #4609
+    all_metrics = all_metrics.loc[:, ~all_metrics.columns.duplicated()]
+    ns_catalog = get_type_map().namespace_catalog
+    row_indices = _analyzer_unit_positions_to_units_rows(sorting_analyzer, nwbfile.units)
+    for metric_name, col_cls in UNITS_TYPED_COLUMNS.items():
+        if metric_name in all_metrics.columns:
+            spec = ns_catalog.get_spec("ndx-spikesorting", col_cls.__name__)
+            analyzer_values = all_metrics[metric_name].to_numpy()
+            nwb_ordered = np.empty_like(analyzer_values)
+            nwb_ordered[row_indices] = analyzer_values
+            nwbfile.units.add_column(
+                name=metric_name,
+                description=spec.doc,
+                data=nwb_ordered,
+                col_cls=col_cls,
+            )
 
 
 def _units_table_id_lookup(units_table) -> dict[str, int]:
@@ -484,7 +413,7 @@ def _units_table_id_lookup(units_table) -> dict[str, int]:
     return {str(uid): i for i, uid in enumerate(ids)}
 
 
-def _analyzer_positions_to_units_rows(sorting_analyzer, units_table) -> list[int]:
+def _analyzer_unit_positions_to_units_rows(sorting_analyzer, units_table) -> list[int]:
     """For each analyzer position i, return the nwbfile.units row index for that unit id.
 
     Raises ValueError if an analyzer unit id has no matching row in the units
@@ -524,7 +453,7 @@ def _build_periods_table(
             "multi-segment support not yet implemented."
         )
     sampling_frequency = sorting_analyzer.sampling_frequency
-    analyzer_pos_to_row = _analyzer_positions_to_units_rows(sorting_analyzer, units_table)
+    analyzer_pos_to_row = _analyzer_unit_positions_to_units_rows(sorting_analyzer, units_table)
 
     start_times = [float(p["start_sample_index"]) / sampling_frequency for p in periods]
     stop_times = [float(p["end_sample_index"]) / sampling_frequency for p in periods]
@@ -552,6 +481,7 @@ def _build_periods_table(
     return table
 
 
+# TODO: simplify this
 def _build_valid_unit_periods_and_qm_time_support(
     sorting_analyzer: "SortingAnalyzer",
     units_table=None,
@@ -620,9 +550,9 @@ def _build_valid_unit_periods_and_qm_time_support(
                 sorting_analyzer=sorting_analyzer,
                 units_table=units_table,
                 table_cls=TimeIntervals,
-                name="quality_metrics_time_support",
+                name="unit_metrics_time_support",
                 description=(
-                    "Per-unit time intervals over which quality_metrics values were "
+                    "Per-unit time intervals over which some of the unit_metrics values were "
                     "computed. Sourced from quality_metrics.params['periods']."
                 ),
             )
@@ -636,7 +566,7 @@ def _convert_units_metrics(
     nwbfile: NWBFile,
     time_support_ref=None,
 ) -> UnitsMetrics | None:
-    """Build a UnitsMetrics instance from SI's ``quality_metrics`` extension.
+    """Build a UnitsMetrics instance from SI's ``metrics`` extension.
 
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
@@ -644,40 +574,18 @@ def _convert_units_metrics(
     metric column whose underlying SI metric has ``supports_periods=True`` gets
     a ``time_support`` attribute pointing to that table. Columns whose metric
     ignores periods (e.g. ``snr``) are left without a link, since the periods
-    didn't actually constrain their values. Returns ``None`` when neither
-    ``quality_metrics`` nor ``template_metrics`` is computed.
+    didn't actually constrain their values. Returns ``None`` when no metrics are computed.
     """
-    qm_ext = sorting_analyzer.get_extension("quality_metrics")
-    tm_ext = sorting_analyzer.get_extension("template_metrics")
-    if qm_ext is None and tm_ext is None:
-        return None
+    df = sorting_analyzer.get_metrics_extension_data()
 
-    # Combine quality_metrics and template_metrics columns into a single
-    # DataFrame. Each column will become a VectorData entry on the UnitsMetrics
-    # table; on read, the loader uses COLUMN_TO_EXTENSION to route each column
-    # back to the right SI extension. We do not pull from spiketrain_metrics
-    # separately because its columns (num_spikes, firing_rate) are aliases of
-    # quality_metrics columns and already pulled via qm_ext.
-    if qm_ext is not None and tm_ext is not None:
-        qm_df = qm_ext.get_data()
-        tm_df = tm_ext.get_data()
-        overlap = set(qm_df.columns) & set(tm_df.columns)
-        if overlap:
-            # In SI 0.104 quality_metrics and template_metrics do not overlap.
-            # Guard for future versions: if a column appears in both, prefer
-            # the quality_metrics value (arbitrary but deterministic).
-            tm_df = tm_df.drop(columns=list(overlap))
-        df = qm_df.join(tm_df)
-    elif qm_ext is not None:
-        df = qm_ext.get_data()
-    else:
-        df = tm_ext.get_data()
+    # We need this until SI 0.105.0 is release (with a bugfix #4609)
+    df = df.loc[:, ~df.columns.duplicated()]
 
     # Per-row unit DTR pointing back to nwbfile.units (one row per unit). We
     # resolve each analyzer unit_id to a nwbfile.units row index by identity
     # rather than position, so the DTR stays correct even if nwbfile.units is
     # reordered or interleaved with units we don't own.
-    dtr_data = _analyzer_positions_to_units_rows(sorting_analyzer, nwbfile.units)
+    dtr_data = _analyzer_unit_positions_to_units_rows(sorting_analyzer, nwbfile.units)
     unit_column = DynamicTableRegion(
         name="unit",
         data=dtr_data,
@@ -693,10 +601,11 @@ def _convert_units_metrics(
     period_supporting_cols = _columns_supporting_periods() if time_support_ref is not None else set()
 
     # Each metric column becomes a UnitVectorData so it can carry the optional
-    # time_support reference. Column names are preserved so the read path can
-    # route each column to the right SI extension via COLUMN_TO_EXTENSION.
+    # time_support reference.
     for col_name in df.columns:
-        col_values = df[col_name].to_numpy().astype(float)
+        if col_name in UNITS_TYPED_COLUMNS:
+            continue  # Skip columns that are promoted to typed VectorData on nwbfile.units
+        col_values = df[col_name].to_numpy()
         col_kwargs = dict(
             name=col_name,
             data=col_values,
@@ -707,30 +616,9 @@ def _convert_units_metrics(
         columns.append(UnitVectorData(**col_kwargs))
 
     return UnitsMetrics(
-        name="quality_metrics",
+        name="unit_metrics",
         description="Run-dependent per-unit metrics from one analysis run.",
         columns=columns,
-    )
-
-
-def _build_column_kwargs(
-    col_cls: type,
-    si_name: str,
-    data: np.ndarray,
-    qm_params: dict,
-) -> dict:
-    """Assemble constructor kwargs for a typed canonical run-dependent column.
-
-    Currently a stub: v1 does not commit any run-dependent typed columns, so
-    this is unused. It is kept as the place where attribute-extraction logic
-    will live when typed run-dependent columns are added in a future version
-    (e.g. pulling SI's ``isi_threshold_ms`` onto a future
-    ``IsiViolationsRatio.refractory_period_ms`` attribute).
-    """
-    return dict(
-        name=si_name,
-        description=col_cls.__doc__ or si_name,
-        data=data,
     )
 
 
@@ -920,7 +808,7 @@ def _convert_all_extensions(sorting_analyzer, nwbfile):  # noqa: C901
         sorting_analyzer, units_table=nwbfile.units
     )
     if vup is not None:
-        converted["valid_unit_periods"] = vup
+        converted["__valid_unit_periods__"] = vup
     if qm_ts is not None:
         converted["__time_intervals__"] = qm_ts
 
@@ -949,10 +837,10 @@ def _build_extensions(sorting_analyzer, nwbfile):
     for attr, obj in converted.items():
         if attr == "__units_metrics__":
             extensions.add_units_metrics(obj)
-        elif attr == "valid_unit_periods":
-            extensions.add_valid_unit_periods(obj)
         elif attr == "__time_intervals__":
             extensions.add_time_intervals(obj)
+        elif attr == "__valid_unit_periods__":
+            extensions.add_valid_unit_periods(obj)
         else:
             setattr(extensions, attr, obj)
     return extensions
@@ -1470,44 +1358,47 @@ def _load_cell_intrinsic_from_units(units_table, sorting_analyzer: "SortingAnaly
     import pandas as pd
     from spikeinterface.core.sortinganalyzer import get_extension_class
 
-    per_extension_columns: dict[str, dict[str, np.ndarray]] = {}
+    # Build a reordering map from nwbfile.units rows to analyzer unit positions
+    # so cell-intrinsic values are associated with the correct units.
+    row_to_analyzer_pos = _dtr_rows_to_analyzer_positions_from_table(units_table, sorting_analyzer)
+    reorder = np.argsort(row_to_analyzer_pos)
+
     for col_name in units_table.colnames:
         col = units_table[col_name]
-        for col_cls, (si_name, si_ext_name) in UNITS_TYPED_COLUMNS.items():
+        for metric_name, col_cls in UNITS_TYPED_COLUMNS.items():
             if isinstance(col, col_cls):
-                per_extension_columns.setdefault(si_ext_name, {})[si_name] = np.asarray(col.data[:])
-                break
-
-    for si_ext_name, columns_dict in per_extension_columns.items():
-        existing = sorting_analyzer.extensions.get(si_ext_name)
-        if existing is not None:
-            # Merge into existing DataFrame; preserve any params/metric_names set
-            # by the prior loader (typically _load_units_metrics for quality_metrics).
-            existing_df = existing.data.get("metrics")
-            if existing_df is not None:
-                for col_name, values in columns_dict.items():
-                    existing_df[col_name] = values
-                existing.params.setdefault("metric_names", []).extend(
-                    [n for n in columns_dict if n not in existing.params["metric_names"]]
-                )
-                existing.params["metrics_to_compute"] = list(existing.params["metric_names"])
-                continue
-
-        ext_class = get_extension_class(si_ext_name)
-        if ext_class is None:
-            continue
-        unit_ids = sorting_analyzer.unit_ids
-        metrics_df = pd.DataFrame(columns_dict, index=unit_ids)
-        ext = ext_class(sorting_analyzer)
-        ext.params = {
-            "metric_names": list(columns_dict.keys()),
-            "metric_params": {},
-            "metrics_to_compute": list(columns_dict.keys()),
-            "delete_existing_metrics": False,
-        }
-        ext.data["metrics"] = metrics_df
-        ext.run_info = {"run_completed": True, "runtime_s": 0.0}
-        sorting_analyzer.extensions[si_ext_name] = ext
+                raw_values = np.asarray(col.data[:])
+                if raw_values.ndim > 1:
+                    raw_values = raw_values[:, 0]
+                reordered_values = raw_values[reorder]
+                target_extensions = find_extension_metric_targets(metric_name)
+                for si_ext_name in target_extensions:
+                    metric_ext = sorting_analyzer.extensions.get(si_ext_name)
+                    if metric_ext is not None:
+                        # If the extension is already present (e.g. from loading a UnitsMetrics), 
+                        # merge this column into it rather than overwriting it.
+                        existing_df = metric_ext.get_data()
+                        if metric_name not in existing_df:
+                            existing_df[metric_name] = reordered_values
+                        metric_ext.params.setdefault("metric_names", []).append(metric_name)
+                        metric_ext.params["metrics_to_compute"] = list(metric_ext.params["metric_names"])
+                    else:
+                        # If the extension is not available, make it from scratch so the metric can be added to it.
+                        # This allows cell-intrinsic metrics to be loaded even when their extension's UnitsMetrics 
+                        # counterpart is missing.
+                        ext_class = get_extension_class(si_ext_name)
+                        unit_ids = sorting_analyzer.unit_ids
+                        metrics_df = pd.DataFrame(data={metric_name: reordered_values}, index=unit_ids)
+                        ext = ext_class(sorting_analyzer)
+                        ext.params = {
+                            "metric_names": [metric_name],
+                            "metric_params": {},
+                            "metrics_to_compute": [metric_name],
+                            "delete_existing_metrics": False,
+                        }
+                        ext.data["metrics"] = metrics_df
+                        ext.run_info = {"run_completed": True, "runtime_s": 0.0}
+                        sorting_analyzer.extensions[si_ext_name] = ext
 
 
 def _collect_units_metrics_columns(nwb_table, sorting_analyzer):
@@ -1518,8 +1409,6 @@ def _collect_units_metrics_columns(nwb_table, sorting_analyzer):
     aligned with ``sorting_analyzer.unit_ids`` regardless of whether the on-disk
     row order matches.
     """
-    import warnings
-
     row_to_analyzer_pos = _dtr_rows_to_analyzer_positions(nwb_table["unit"], sorting_analyzer)
     # Permutation that places UnitsMetrics row i's value at the slot corresponding
     # to its analyzer unit position in the output array.
@@ -1533,27 +1422,10 @@ def _collect_units_metrics_columns(nwb_table, sorting_analyzer):
         col = nwb_table[col_name]
         if time_support_link is None:
             time_support_link = getattr(col, "time_support", None)
-        # Typed-column registry path (empty in v1; future-proofing).
-        matched = False
-        for col_cls, (si_name, si_ext_name) in UNITS_METRICS_TYPED_COLUMNS.items():
-            if isinstance(col, col_cls):
-                raw = np.asarray(col.data[:])
-                per_extension_columns.setdefault(si_ext_name, {})[si_name] = raw[reorder]
-                matched = True
-                break
-        if matched:
-            continue
-        targets = COLUMN_TO_EXTENSION.get(col_name)
-        if targets is None:
-            warnings.warn(
-                f"Column {col_name!r} on UnitsMetrics is not in "
-                "COLUMN_TO_EXTENSION; routing to quality_metrics by default. "
-                "Update the dict in utils.py to silence this warning.",
-                stacklevel=2,
-            )
-            targets = ("quality_metrics",)
+
+        si_ext_targets = find_extension_metric_targets(col_name)
         values = np.asarray(col.data[:])[reorder]
-        for si_ext_name in targets:
+        for si_ext_name in si_ext_targets:
             per_extension_columns.setdefault(si_ext_name, {})[col_name] = values
     return per_extension_columns, time_support_link
 
@@ -1563,7 +1435,7 @@ def _load_units_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None
 
     Each UnitsMetrics row holds one unit's metric values; column names identify
     the metric. The loader routes each column to the SI extension it belongs to
-    using ``COLUMN_TO_EXTENSION``. A column listed under multiple extensions
+    using ``find_extension_metric_targets``. A column listed under multiple extensions
     (e.g., ``num_spikes`` belongs to both ``quality_metrics`` and
     ``spiketrain_metrics``) is replicated into each target. A column not in the
     dict falls back to ``quality_metrics`` (matching pre-fix behavior) and is
@@ -1645,6 +1517,28 @@ def _dtr_rows_to_analyzer_positions(unit_dtr, sorting_analyzer) -> np.ndarray:
                 f"but that id is not in sorting_analyzer.unit_ids: {list(analyzer_id_to_pos.keys())}"
             )
         out[i] = analyzer_id_to_pos[uid]
+    return out
+
+
+def _dtr_rows_to_analyzer_positions_from_table(units_table, sorting_analyzer) -> np.ndarray:
+    """Map every row in a units table to the corresponding analyzer unit position.
+
+    Returns an array of length ``len(units_table)`` where ``out[row_idx]`` is the
+    positional index into ``sorting_analyzer.unit_ids`` for the unit at that row.
+    Uses the same id-resolution logic as ``_dtr_rows_to_analyzer_positions``.
+    """
+    row_to_id = {row_idx: uid for uid, row_idx in _units_table_id_lookup(units_table).items()}
+    analyzer_id_to_pos = {str(uid): pos for pos, uid in enumerate(sorting_analyzer.unit_ids)}
+    n_rows = len(units_table)
+    out = np.empty(n_rows, dtype=np.int64)
+    for row_idx in range(n_rows):
+        uid = row_to_id[row_idx]
+        if uid not in analyzer_id_to_pos:
+            raise ValueError(
+                f"nwbfile.units row {row_idx} (unit id {uid!r}) is not in "
+                f"sorting_analyzer.unit_ids: {list(analyzer_id_to_pos.keys())}"
+            )
+        out[row_idx] = analyzer_id_to_pos[uid]
     return out
 
 

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -8,6 +8,7 @@ import numpy as np
 from hdmf.common import VectorData, VectorIndex, DynamicTableRegion
 from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries
+from pynwb.epoch import TimeIntervals
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -28,7 +29,7 @@ from ndx_spikesorting import (
     PCAProjectionsByChannel,
     PCAProjectionsConcatenated,
     FiringRate,
-    MetricVectorData,
+    UnitVectorData,
     UnitsMetrics,
     ValidUnitPeriods,
     SpikeSortingExtensions,
@@ -120,6 +121,41 @@ COLUMN_TO_EXTENSION: dict[str, tuple[str, ...]] = {
     "num_spikes": ("quality_metrics", "spiketrain_metrics"),
     "firing_rate": ("quality_metrics", "spiketrain_metrics"),
 }
+
+
+def _columns_supporting_periods() -> set[str]:
+    """Set of metric column names whose underlying SI metric respects ``periods``.
+
+    Walks ``ComputeQualityMetrics`` and ``ComputeSpikeTrainMetrics`` metric
+    lists and collects ``metric_columns.keys()`` for each metric class whose
+    ``supports_periods`` flag is True. Template metrics are skipped because
+    none of them respect periods (template shape is time-invariant).
+
+    Result is used by the writer to decide which metric columns receive a
+    ``time_support`` reference: only the columns whose values actually depend
+    on the periods get a link. Columns whose values are computed ignoring
+    ``periods`` (e.g. ``snr``, PCA-based separability metrics) get no link
+    even when ``qm_ext.params["periods"]`` is set, because the periods didn't
+    actually constrain those values.
+    """
+    cols: set[str] = set()
+    try:
+        from spikeinterface.metrics.quality.quality_metrics import ComputeQualityMetrics
+
+        for m in ComputeQualityMetrics.metric_list:
+            if getattr(m, "supports_periods", False):
+                cols.update(m.metric_columns.keys())
+    except ImportError:
+        pass
+    try:
+        from spikeinterface.metrics.spiketrain.spiketrain_metrics import ComputeSpikeTrainMetrics
+
+        for m in ComputeSpikeTrainMetrics.metric_list:
+            if getattr(m, "supports_periods", False):
+                cols.update(m.metric_columns.keys())
+    except ImportError:
+        pass
+    return cols
 
 
 def templates_to_dense(templates: Templates, num_channels: int) -> np.ndarray:
@@ -467,20 +503,149 @@ def _analyzer_positions_to_units_rows(sorting_analyzer, units_table) -> list[int
     return [id_lookup[uid] for uid in analyzer_ids]
 
 
+def _build_periods_table(
+    *,
+    periods,
+    sorting_analyzer: "SortingAnalyzer",
+    units_table,
+    table_cls,
+    name: str,
+    description: str,
+):
+    """Build a TimeIntervals-shaped table (rows = (start, stop, unit DTR)) from periods.
+
+    Used to construct both ValidUnitPeriods instances (table_cls=ValidUnitPeriods)
+    and plain TimeIntervals instances (table_cls=TimeIntervals) from SI's
+    structured periods arrays.
+    """
+    if sorting_analyzer.get_num_segments() > 1:
+        raise NotImplementedError(
+            "Periods round-trip is single-segment only; "
+            "multi-segment support not yet implemented."
+        )
+    sampling_frequency = sorting_analyzer.sampling_frequency
+    analyzer_pos_to_row = _analyzer_positions_to_units_rows(sorting_analyzer, units_table)
+
+    start_times = [float(p["start_sample_index"]) / sampling_frequency for p in periods]
+    stop_times = [float(p["end_sample_index"]) / sampling_frequency for p in periods]
+    unit_row_indices = [analyzer_pos_to_row[int(p["unit_index"])] for p in periods]
+
+    table = table_cls(name=name, description=description)
+    # ValidUnitPeriods declares `unit` as a required column in its spec, so it's
+    # already on the table after construction. Plain TimeIntervals doesn't; we
+    # add it ourselves. Either way, add_row needs `unit` to exist before rows
+    # are appended (add_row validates every existing column receives a value).
+    if "unit" not in table.colnames:
+        table.add_column(
+            name="unit",
+            description="Reference to units table for each row.",
+            table=units_table,
+        )
+    else:
+        # Bind the existing typed `unit` column to nwbfile.units. The empty
+        # DTR doesn't carry a table reference until we either pass `table=` to
+        # the constructor (which doesn't fit our deferred construction here)
+        # or set it explicitly.
+        table["unit"].table = units_table
+    for start, stop, unit_row in zip(start_times, stop_times, unit_row_indices):
+        table.add_row(start_time=start, stop_time=stop, unit=unit_row)
+    return table
+
+
+def _build_valid_unit_periods_and_qm_time_support(
+    sorting_analyzer: "SortingAnalyzer",
+    units_table=None,
+):
+    """Build the (ValidUnitPeriods, qm_time_support) pair for one analyzer.
+
+    Two distinct interval sources may exist on a SortingAnalyzer:
+
+    1. The ``valid_unit_periods`` SI extension's output. Written as a
+       ``ValidUnitPeriods`` instance.
+    2. ``quality_metrics.params["periods"]``. Written as a plain
+       ``TimeIntervals`` instance with a ``unit`` DTR.
+
+    When both exist with equal data (strict ``np.array_equal`` on the structured
+    array), only the ValidUnitPeriods is written; metric columns link to it.
+    When they differ, both are written; metric columns link to the qm-derived
+    table because that's what the metrics were actually computed over.
+
+    Returns a tuple ``(vup, qm_ts, ts_ref)``:
+    - ``vup``: ValidUnitPeriods or None.
+    - ``qm_ts``: plain TimeIntervals (only when qm periods differ from vup) or None.
+    - ``ts_ref``: the table to link from MetricVectorData.time_support, or None.
+    """
+    vup_ext = sorting_analyzer.get_extension("valid_unit_periods")
+    qm_ext = sorting_analyzer.get_extension("quality_metrics")
+
+    vup_periods = vup_ext.get_data(outputs="numpy") if vup_ext is not None else None
+    if vup_periods is not None and len(vup_periods) == 0:
+        vup_periods = None
+
+    qm_periods = qm_ext.params.get("periods") if qm_ext is not None and qm_ext.params else None
+    if qm_periods is not None and len(qm_periods) == 0:
+        qm_periods = None
+
+    vup = None
+    qm_ts = None
+    ts_ref = None
+
+    if vup_periods is not None:
+        vup = _build_periods_table(
+            periods=vup_periods,
+            sorting_analyzer=sorting_analyzer,
+            units_table=units_table,
+            table_cls=ValidUnitPeriods,
+            name="valid_unit_periods",
+            description=(
+                "Valid time periods per unit from spike sorting quality estimation."
+            ),
+        )
+
+    if qm_periods is not None:
+        sources_equal = (
+            vup_periods is not None
+            and qm_periods.dtype == vup_periods.dtype
+            and np.array_equal(qm_periods, vup_periods)
+        )
+        if sources_equal:
+            # qm and SI ext data are identical; reuse the single ValidUnitPeriods
+            # as the time-support target.
+            ts_ref = vup
+        else:
+            # qm periods differ from (or exist without) the SI extension data.
+            # Write a plain TimeIntervals dedicated to the qm time support.
+            qm_ts = _build_periods_table(
+                periods=qm_periods,
+                sorting_analyzer=sorting_analyzer,
+                units_table=units_table,
+                table_cls=TimeIntervals,
+                name="quality_metrics_time_support",
+                description=(
+                    "Per-unit time intervals over which quality_metrics values were "
+                    "computed. Sourced from quality_metrics.params['periods']."
+                ),
+            )
+            ts_ref = qm_ts
+
+    return vup, qm_ts, ts_ref
+
+
 def _convert_units_metrics(
     sorting_analyzer: "SortingAnalyzer",
     nwbfile: NWBFile,
-    time_support_ref: "ValidUnitPeriods | None" = None,
+    time_support_ref=None,
 ) -> UnitsMetrics | None:
     """Build a UnitsMetrics instance from SI's ``quality_metrics`` extension.
 
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
-    as ``MetricVectorData`` columns. When ``time_support_ref`` is provided, each
-    metric column gets a ``time_support`` attribute pointing to that
-    ``ValidUnitPeriods`` table, so the per-unit constraint intervals are stored
-    once and referenced by every column they apply to. Returns ``None`` when
-    neither ``quality_metrics`` nor ``template_metrics`` is computed.
+    as ``UnitVectorData`` columns. When ``time_support_ref`` is provided, each
+    metric column whose underlying SI metric has ``supports_periods=True`` gets
+    a ``time_support`` attribute pointing to that table. Columns whose metric
+    ignores periods (e.g. ``snr``) are left without a link, since the periods
+    didn't actually constrain their values. Returns ``None`` when neither
+    ``quality_metrics`` nor ``template_metrics`` is computed.
     """
     qm_ext = sorting_analyzer.get_extension("quality_metrics")
     tm_ext = sorting_analyzer.get_extension("template_metrics")
@@ -522,7 +687,12 @@ def _convert_units_metrics(
 
     columns = [unit_column]
 
-    # Each metric column becomes a MetricVectorData so it can carry the optional
+    # Cache the set of column names whose underlying metric respects periods.
+    # We only attach the time_support reference to those; columns whose metric
+    # ignores periods get no link even when a time support table exists.
+    period_supporting_cols = _columns_supporting_periods() if time_support_ref is not None else set()
+
+    # Each metric column becomes a UnitVectorData so it can carry the optional
     # time_support reference. Column names are preserved so the read path can
     # route each column to the right SI extension via COLUMN_TO_EXTENSION.
     for col_name in df.columns:
@@ -532,72 +702,14 @@ def _convert_units_metrics(
             data=col_values,
             description=f"Run-dependent metric: {col_name}.",
         )
-        if time_support_ref is not None:
+        if time_support_ref is not None and col_name in period_supporting_cols:
             col_kwargs["time_support"] = time_support_ref
-        columns.append(MetricVectorData(**col_kwargs))
+        columns.append(UnitVectorData(**col_kwargs))
 
     return UnitsMetrics(
         name="quality_metrics",
         description="Run-dependent per-unit metrics from one analysis run.",
         columns=columns,
-    )
-
-
-def _build_valid_unit_periods(
-    sorting_analyzer: "SortingAnalyzer",
-    units_table=None,
-) -> ValidUnitPeriods | None:
-    """Build a ValidUnitPeriods table from the best available periods source.
-
-    Prefers ``quality_metrics.params["periods"]`` when set (that array is what
-    the metric columns are actually constrained by). Falls back to the SI
-    ``valid_unit_periods`` extension when only that is available. Returns
-    ``None`` if neither source has periods.
-    """
-    qm_ext = sorting_analyzer.get_extension("quality_metrics")
-    qm_periods = qm_ext.params.get("periods") if qm_ext is not None and qm_ext.params else None
-    if qm_periods is not None and len(qm_periods) > 0:
-        periods = qm_periods
-    else:
-        vup_ext = sorting_analyzer.get_extension("valid_unit_periods")
-        if vup_ext is None:
-            return None
-        periods = vup_ext.get_data(outputs="numpy")
-        if len(periods) == 0:
-            return None
-
-    if sorting_analyzer.get_num_segments() > 1:
-        raise NotImplementedError(
-            "ValidUnitPeriods round-trip is single-segment only; "
-            "multi-segment support not yet implemented."
-        )
-
-    sampling_frequency = sorting_analyzer.sampling_frequency
-    analyzer_pos_to_row = _analyzer_positions_to_units_rows(sorting_analyzer, units_table)
-
-    start_times = [float(p["start_sample_index"]) / sampling_frequency for p in periods]
-    stop_times = [float(p["end_sample_index"]) / sampling_frequency for p in periods]
-    unit_row_indices = [analyzer_pos_to_row[int(p["unit_index"])] for p in periods]
-
-    vup_unit_column = DynamicTableRegion(
-        name="unit",
-        data=unit_row_indices,
-        description="Reference to units table for each valid period.",
-        table=units_table,
-    )
-
-    return ValidUnitPeriods(
-        name="valid_unit_periods",
-        description="Valid time periods per unit from spike sorting quality estimation.",
-        columns=[
-            VectorData(
-                name="start_time", data=start_times, description="Start time of each valid period in seconds."
-            ),
-            VectorData(
-                name="stop_time", data=stop_times, description="Stop time of each valid period in seconds."
-            ),
-            vup_unit_column,
-        ],
     )
 
 
@@ -798,19 +910,24 @@ def _convert_all_extensions(sorting_analyzer, nwbfile):  # noqa: C901
             raise ValueError("PCA projections require waveforms to be computed.")
         converted.update(_convert_pca(sorting_analyzer, nwbfile, converted["waveforms"]))
 
-    # Build ValidUnitPeriods first (preferring quality_metrics.params["periods"]
-    # when set, since that's what the metric columns are actually constrained
-    # by). UnitsMetrics columns reference this table via their time_support
-    # attribute, so the intervals are stored once and pointed to by every
-    # column they apply to.
-    vup = _build_valid_unit_periods(sorting_analyzer, units_table=nwbfile.units)
+    # Build interval tables: a ValidUnitPeriods if the SI valid_unit_periods
+    # extension exists, and/or a plain TimeIntervals if quality_metrics has its
+    # own periods that differ from the SI extension's data. The third return is
+    # whichever table should serve as the time_support reference for period-
+    # supporting metric columns (the qm-derived TimeIntervals when periods
+    # diverge, the ValidUnitPeriods when they coincide or only it exists).
+    vup, qm_ts, ts_ref = _build_valid_unit_periods_and_qm_time_support(
+        sorting_analyzer, units_table=nwbfile.units
+    )
     if vup is not None:
         converted["valid_unit_periods"] = vup
+    if qm_ts is not None:
+        converted["__time_intervals__"] = qm_ts
 
     # Run-dependent metrics flow into a UnitsMetrics instance (or several, as
     # support for multiple curation runs is added). For v1 there is one
     # UnitsMetrics per file, sourced from SI's quality_metrics extension.
-    units_metrics = _convert_units_metrics(sorting_analyzer, nwbfile, time_support_ref=vup)
+    units_metrics = _convert_units_metrics(sorting_analyzer, nwbfile, time_support_ref=ts_ref)
     if units_metrics is not None:
         converted["__units_metrics__"] = units_metrics
 
@@ -832,6 +949,10 @@ def _build_extensions(sorting_analyzer, nwbfile):
     for attr, obj in converted.items():
         if attr == "__units_metrics__":
             extensions.add_units_metrics(obj)
+        elif attr == "valid_unit_periods":
+            extensions.add_valid_unit_periods(obj)
+        elif attr == "__time_intervals__":
+            extensions.add_time_intervals(obj)
         else:
             setattr(extensions, attr, obj)
     return extensions
@@ -1554,9 +1675,21 @@ def _load_valid_unit_periods_from_nwb(extensions, sorting_analyzer):
     from spikeinterface.core.base import unit_period_dtype
     from spikeinterface.core.sortinganalyzer import get_extension_class
 
-    valid_periods_nwb = getattr(extensions, "valid_unit_periods", None)
-    if valid_periods_nwb is None:
+    # valid_unit_periods is now a LabelledDict (quantity="*"). For SI extension
+    # restoration we pick the one named "valid_unit_periods" by convention; if
+    # not present, the first instance (or none).
+    valid_periods_dict = getattr(extensions, "valid_unit_periods", None)
+    if not valid_periods_dict:
         return
+    if hasattr(valid_periods_dict, "get") and "valid_unit_periods" in valid_periods_dict:
+        valid_periods_nwb = valid_periods_dict["valid_unit_periods"]
+    elif hasattr(valid_periods_dict, "values"):
+        try:
+            valid_periods_nwb = next(iter(valid_periods_dict.values()))
+        except StopIteration:
+            return
+    else:
+        valid_periods_nwb = valid_periods_dict
 
     start_times = np.array(valid_periods_nwb["start_time"][:], dtype=np.float64)
     stop_times = np.array(valid_periods_nwb["stop_time"][:], dtype=np.float64)

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -367,8 +367,8 @@ def _convert_unit_metrics(
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
     as typed columns. If ``valid_unit_periods`` is also computed, the per-unit
-    valid windows are written as ``obs_intervals`` on the table. Returns
-    ``None`` when ``quality_metrics`` is not computed.
+    valid windows are written as ``computation_intervals`` on the table.
+    Returns ``None`` when ``quality_metrics`` is not computed.
     """
     qm_ext = sorting_analyzer.get_extension("quality_metrics")
     if qm_ext is None:
@@ -441,18 +441,21 @@ def _convert_unit_metrics(
             running += len(windows)
             cumulative.append(running)
 
-        obs_intervals_vd = VectorData(
-            name="obs_intervals",
+        computation_intervals_vd = VectorData(
+            name="computation_intervals",
             data=np.array(flat_intervals, dtype=np.float64) if flat_intervals else np.zeros((0, 2)),
-            description="Per-unit observation intervals (start, stop) in seconds.",
+            description=(
+                "Per-unit time intervals (start, stop) in seconds over which this row's "
+                "metric values were computed."
+            ),
         )
-        obs_intervals_index = VectorIndex(
-            name="obs_intervals_index",
+        computation_intervals_index = VectorIndex(
+            name="computation_intervals_index",
             data=np.array(cumulative, dtype=np.int64),
-            target=obs_intervals_vd,
+            target=computation_intervals_vd,
         )
-        columns.append(obs_intervals_vd)
-        columns.append(obs_intervals_index)
+        columns.append(computation_intervals_vd)
+        columns.append(computation_intervals_index)
 
     return UnitMetrics(
         name="quality_metrics",
@@ -1308,7 +1311,7 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
         per_extension_params: dict[str, dict] = {}
 
         for col_name in nwb_table.colnames:
-            if col_name in ("unit", "obs_intervals", "obs_intervals_index"):
+            if col_name in ("unit", "computation_intervals", "computation_intervals_index"):
                 continue
             col = nwb_table[col_name]
             # First try the typed-column registry (empty in v1; kept for forward

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -512,17 +512,16 @@ def _convert_unit_metrics(
             )
         )
 
-    vup_ext = sorting_analyzer.get_extension("valid_unit_periods")
-    if vup_ext is not None:
+    qm_periods = qm_params.get("periods") if qm_params else None
+    if qm_periods is not None and len(qm_periods) > 0:
         if sorting_analyzer.get_num_segments() > 1:
             raise NotImplementedError(
-                "valid_unit_periods round-trip is single-segment only; "
+                "time_support round-trip is single-segment only; "
                 "multi-segment support not yet implemented."
             )
         sampling_frequency = sorting_analyzer.sampling_frequency
-        valid_periods_data = vup_ext.get_data(outputs="numpy")
         per_unit_windows: list[list[tuple[float, float]]] = [[] for _ in range(n_units)]
-        for period in valid_periods_data:
+        for period in qm_periods:
             unit_index = int(period["unit_index"])
             start_s = float(period["start_sample_index"]) / sampling_frequency
             stop_s = float(period["end_sample_index"]) / sampling_frequency
@@ -1398,6 +1397,7 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
     import warnings
 
     import pandas as pd
+    from spikeinterface.core.base import unit_period_dtype
     from spikeinterface.core.sortinganalyzer import get_extension_class
 
     unit_metrics = getattr(extensions, "unit_metrics", None)
@@ -1441,6 +1441,12 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
             for si_ext_name in targets:
                 per_extension_columns.setdefault(si_ext_name, {})[col_name] = values
 
+        # Reconstruct the structured `periods` array from the ragged
+        # (time_support, time_support_index) columns when present. The result
+        # is fed into quality_metrics.params["periods"] so SI sees the same
+        # per-unit windows the metric values were computed over.
+        qm_periods = _periods_from_time_support(nwb_table, sorting_analyzer, unit_period_dtype)
+
         for si_ext_name, columns_dict in per_extension_columns.items():
             ext_class = get_extension_class(si_ext_name)
             if ext_class is None:
@@ -1457,6 +1463,8 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
                     if n not in metric_names:
                         metric_names.append(n)
                 existing.params["metrics_to_compute"] = list(metric_names)
+                if qm_periods is not None and si_ext_name == "quality_metrics":
+                    existing.params["periods"] = qm_periods
                 continue
             metrics_df = pd.DataFrame(columns_dict, index=unit_ids)
             params = per_extension_params.get(si_ext_name, {})
@@ -1467,9 +1475,42 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
                 "metrics_to_compute": list(columns_dict.keys()),
                 "delete_existing_metrics": False,
             }
+            if qm_periods is not None and si_ext_name == "quality_metrics":
+                ext.params["periods"] = qm_periods
             ext.data["metrics"] = metrics_df
             ext.run_info = {"run_completed": True, "runtime_s": 0.0}
             sorting_analyzer.extensions[si_ext_name] = ext
+
+
+def _periods_from_time_support(nwb_table, sorting_analyzer, unit_period_dtype):
+    """Build SI's structured periods array from a UnitMetrics time_support column.
+
+    Returns None when the table has no time_support column. Single-segment only
+    (segment_index=0).
+    """
+    if "time_support" not in nwb_table.colnames:
+        return None
+    # When the column is ragged, nwb_table["time_support"] resolves to its
+    # VectorIndex (offsets in .data, underlying values in .target.data).
+    ts_accessor = nwb_table["time_support"]
+    end_offsets = np.asarray(ts_accessor.data[:], dtype=np.int64)
+    flat_intervals = np.asarray(ts_accessor.target.data[:], dtype=np.float64)
+    unit_indices_col = np.asarray(nwb_table["unit"].data[:], dtype=np.int64)
+    sampling_frequency = sorting_analyzer.sampling_frequency
+
+    n_periods = int(end_offsets[-1]) if len(end_offsets) > 0 else 0
+    periods = np.zeros(n_periods, dtype=unit_period_dtype)
+    cursor = 0
+    for row_idx, end in enumerate(end_offsets):
+        unit_index = int(unit_indices_col[row_idx])
+        for window in flat_intervals[cursor:end]:
+            start_s, stop_s = float(window[0]), float(window[1])
+            periods["segment_index"][cursor] = 0
+            periods["start_sample_index"][cursor] = int(round(start_s * sampling_frequency))
+            periods["end_sample_index"][cursor] = int(round(stop_s * sampling_frequency))
+            periods["unit_index"][cursor] = unit_index
+            cursor += 1
+    return periods
 
 
 def _load_valid_unit_periods_from_nwb(extensions, sorting_analyzer):

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -1441,12 +1441,6 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
             for si_ext_name in targets:
                 per_extension_columns.setdefault(si_ext_name, {})[col_name] = values
 
-        # Reconstruct the structured `periods` array from the ragged
-        # (time_support, time_support_index) columns when present. The result
-        # is fed into quality_metrics.params["periods"] so SI sees the same
-        # per-unit windows the metric values were computed over.
-        qm_periods = _periods_from_time_support(nwb_table, sorting_analyzer, unit_period_dtype)
-
         for si_ext_name, columns_dict in per_extension_columns.items():
             ext_class = get_extension_class(si_ext_name)
             if ext_class is None:
@@ -1463,8 +1457,6 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
                     if n not in metric_names:
                         metric_names.append(n)
                 existing.params["metrics_to_compute"] = list(metric_names)
-                if qm_periods is not None and si_ext_name == "quality_metrics":
-                    existing.params["periods"] = qm_periods
                 continue
             metrics_df = pd.DataFrame(columns_dict, index=unit_ids)
             params = per_extension_params.get(si_ext_name, {})
@@ -1475,11 +1467,17 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
                 "metrics_to_compute": list(columns_dict.keys()),
                 "delete_existing_metrics": False,
             }
-            if qm_periods is not None and si_ext_name == "quality_metrics":
-                ext.params["periods"] = qm_periods
             ext.data["metrics"] = metrics_df
             ext.run_info = {"run_completed": True, "runtime_s": 0.0}
             sorting_analyzer.extensions[si_ext_name] = ext
+
+        # Restore quality_metrics.params["periods"] from the ragged time_support
+        # column when present, so SI sees the same per-unit windows the metric
+        # values were computed over.
+        qm_periods = _periods_from_time_support(nwb_table, sorting_analyzer, unit_period_dtype)
+        qm_ext = sorting_analyzer.extensions.get("quality_metrics")
+        if qm_periods is not None and qm_ext is not None:
+            qm_ext.params["periods"] = qm_periods
 
 
 def _periods_from_time_support(nwb_table, sorting_analyzer, unit_period_dtype):

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -366,7 +366,9 @@ def _convert_unit_metrics(
 
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
-    as typed columns. Returns ``None`` when ``quality_metrics`` is not computed.
+    as typed columns. If ``valid_unit_periods`` is also computed, the per-unit
+    valid windows are written as ``obs_intervals`` on the table. Returns
+    ``None`` when ``quality_metrics`` is not computed.
     """
     qm_ext = sorting_analyzer.get_extension("quality_metrics")
     if qm_ext is None:
@@ -413,6 +415,44 @@ def _convert_unit_metrics(
                 description=f"Run-dependent metric: {col_name}.",
             )
         )
+
+    vup_ext = sorting_analyzer.get_extension("valid_unit_periods")
+    if vup_ext is not None:
+        if sorting_analyzer.get_num_segments() > 1:
+            raise NotImplementedError(
+                "valid_unit_periods round-trip is single-segment only; "
+                "multi-segment support not yet implemented."
+            )
+        sampling_frequency = sorting_analyzer.sampling_frequency
+        valid_periods_data = vup_ext.get_data(outputs="numpy")
+        per_unit_windows: list[list[tuple[float, float]]] = [[] for _ in range(n_units)]
+        for period in valid_periods_data:
+            unit_index = int(period["unit_index"])
+            start_s = float(period["start_sample_index"]) / sampling_frequency
+            stop_s = float(period["end_sample_index"]) / sampling_frequency
+            per_unit_windows[unit_index].append((start_s, stop_s))
+
+        flat_intervals: list[list[float]] = []
+        cumulative = []
+        running = 0
+        for windows in per_unit_windows:
+            for start_s, stop_s in windows:
+                flat_intervals.append([start_s, stop_s])
+            running += len(windows)
+            cumulative.append(running)
+
+        obs_intervals_vd = VectorData(
+            name="obs_intervals",
+            data=np.array(flat_intervals, dtype=np.float64) if flat_intervals else np.zeros((0, 2)),
+            description="Per-unit observation intervals (start, stop) in seconds.",
+        )
+        obs_intervals_index = VectorIndex(
+            name="obs_intervals_index",
+            data=np.array(cumulative, dtype=np.int64),
+            target=obs_intervals_vd,
+        )
+        columns.append(obs_intervals_vd)
+        columns.append(obs_intervals_index)
 
     return UnitMetrics(
         name="quality_metrics",
@@ -1268,7 +1308,7 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
         per_extension_params: dict[str, dict] = {}
 
         for col_name in nwb_table.colnames:
-            if col_name == "unit":
+            if col_name in ("unit", "obs_intervals", "obs_intervals_index"):
                 continue
             col = nwb_table[col_name]
             # First try the typed-column registry (empty in v1; kept for forward

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -368,7 +368,7 @@ def _convert_unit_metrics(
     Each row of the table references one unit (via the ``unit``
     ``DynamicTableRegion``) and carries that unit's run-dependent metric values
     as typed columns. If ``valid_unit_periods`` is also computed, the per-unit
-    valid windows are written as ``computation_intervals`` on the table.
+    valid windows are written as ``time_support`` on the table.
     Returns ``None`` when ``quality_metrics`` is not computed.
     """
     qm_ext = sorting_analyzer.get_extension("quality_metrics")
@@ -442,21 +442,21 @@ def _convert_unit_metrics(
             running += len(windows)
             cumulative.append(running)
 
-        computation_intervals_vd = VectorData(
-            name="computation_intervals",
+        time_support_vd = VectorData(
+            name="time_support",
             data=np.array(flat_intervals, dtype=np.float64) if flat_intervals else np.zeros((0, 2)),
             description=(
                 "Per-unit time intervals (start, stop) in seconds over which this row's "
                 "metric values were computed."
             ),
         )
-        computation_intervals_index = VectorIndex(
-            name="computation_intervals_index",
+        time_support_index = VectorIndex(
+            name="time_support_index",
             data=np.array(cumulative, dtype=np.int64),
-            target=computation_intervals_vd,
+            target=time_support_vd,
         )
-        columns.append(computation_intervals_vd)
-        columns.append(computation_intervals_index)
+        columns.append(time_support_vd)
+        columns.append(time_support_index)
 
     return UnitMetrics(
         name="quality_metrics",
@@ -1312,7 +1312,7 @@ def _load_unit_metrics(extensions, sorting_analyzer: "SortingAnalyzer") -> None:
         per_extension_params: dict[str, dict] = {}
 
         for col_name in nwb_table.colnames:
-            if col_name in ("unit", "computation_intervals", "computation_intervals_index"):
+            if col_name in ("unit", "time_support", "time_support_index"):
                 continue
             col = nwb_table[col_name]
             # First try the typed-column registry (empty in v1; kept for forward

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -24,6 +24,7 @@ from ndx_spikesorting import (
     PCAProjectionsByChannel,
     PCAProjectionsConcatenated,
     UnitMetrics,
+    ValidUnitPeriods,
     SpikeSortingExtensions,
     SpikeSortingContainer,
 )
@@ -1368,15 +1369,8 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
             )
 
 
-def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_obs_intervals: bool = True):
-    """Create a mock UnitMetrics with plain (untyped) VectorData metric columns.
-
-    In v1 no run-dependent metric is canonized as a typed column type (each
-    candidate needs multiple attributes to capture cross-pipeline variability;
-    see canonical_unit_columns.md in the vault). Columns are stored as plain
-    VectorData with their SI metric names preserved. Optionally adds a ragged
-    obs_intervals column with two windows per unit.
-    """
+def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3):
+    """Create a mock UnitMetrics with plain (untyped) VectorData metric columns."""
     unit_column = DynamicTableRegion(
         name="unit",
         data=list(range(num_units)),
@@ -1392,44 +1386,20 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_obs_inte
         unit_column,
         VectorData(
             name="presence_ratio",
-            description="Fraction of bins in which the unit fired (plain column; not canonized).",
+            description="Fraction of bins in which the unit fired.",
             data=presence_data,
         ),
         VectorData(
             name="isi_violations_ratio",
-            description="Fraction of ISIs below the refractory threshold (plain column; not canonized).",
+            description="Fraction of ISIs below the refractory threshold.",
             data=isi_data,
         ),
         VectorData(
             name="amplitude_cutoff",
-            description="Estimated fraction of spikes missed (plain column; not canonized).",
+            description="Estimated fraction of spikes missed.",
             data=cutoff_data,
         ),
     ]
-
-    if with_obs_intervals:
-        # Two disjoint windows per unit
-        flat = []
-        cumulative = []
-        running = 0
-        for unit_idx in range(num_units):
-            flat.append([unit_idx * 10.0, unit_idx * 10.0 + 2.0])
-            flat.append([unit_idx * 10.0 + 3.0, unit_idx * 10.0 + 4.5])
-            running += 2
-            cumulative.append(running)
-
-        obs_intervals_vd = VectorData(
-            name="obs_intervals",
-            data=np.array(flat, dtype=np.float64),
-            description="Per-unit observation intervals (start, stop) in seconds.",
-        )
-        obs_intervals_idx = VectorIndex(
-            name="obs_intervals_index",
-            data=np.array(cumulative, dtype=np.int64),
-            target=obs_intervals_vd,
-        )
-        columns.append(obs_intervals_vd)
-        columns.append(obs_intervals_idx)
 
     return UnitMetrics(
         name="quality_metrics",
@@ -1438,37 +1408,51 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_obs_inte
     )
 
 
+def create_mock_valid_unit_periods(nwbfile: NWBFile, num_units: int = 3, periods_per_unit: int = 2):
+    """Create mock ValidUnitPeriods with time intervals for each unit."""
+    start_times = []
+    stop_times = []
+    unit_indices = []
+
+    for unit_index in range(num_units):
+        for p in range(periods_per_unit):
+            start = unit_index * 10.0 + p * 3.0
+            stop = start + 2.0
+            start_times.append(start)
+            stop_times.append(stop)
+            unit_indices.append(unit_index)
+
+    units = DynamicTableRegion(
+        name="unit",
+        data=unit_indices,
+        description="Reference to units table for each valid period.",
+        table=nwbfile.units,
+    )
+
+    valid_unit_periods = ValidUnitPeriods(
+        name="valid_unit_periods",
+        description="Valid periods for each unit.",
+        columns=[
+            VectorData(name="start_time", data=start_times, description="Start time of each valid period."),
+            VectorData(name="stop_time", data=stop_times, description="Stop time of each valid period."),
+            units,
+        ],
+    )
+    return valid_unit_periods
+
+
 class TestUnitMetricsConstructor(TestCase):
     """Unit tests for UnitMetrics constructor."""
 
-    def test_constructor_without_intervals(self):
-        """UnitMetrics is constructed with typed metric columns."""
+    def test_constructor(self):
+        """UnitMetrics is constructed with the expected columns."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=False)
+        run = create_mock_unit_metrics(nwbfile)
 
         self.assertEqual(run.name, "quality_metrics")
         self.assertIn("presence_ratio", run.colnames)
         self.assertIn("isi_violations_ratio", run.colnames)
         self.assertIn("unit", run.colnames)
-        self.assertNotIn("obs_intervals", run.colnames)
-        # 3 units => 3 rows
-        self.assertEqual(len(run["presence_ratio"].data), 3)
-
-    def test_constructor_with_intervals(self):
-        """UnitMetrics carries obs_intervals as a ragged column."""
-        nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=True)
-
-        self.assertIn("obs_intervals", run.colnames)
-        # 3 units * 2 windows => 6 intervals in the flat data
-        self.assertEqual(run["obs_intervals"].target.data.shape, (6, 2))
-
-    def test_plain_column_values(self):
-        """UnitMetrics stores run-dependent metrics as plain VectorData (v1)."""
-        nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=False)
-
-        # No typed-column attributes in v1; columns are plain VectorData.
         self.assertEqual(len(run["presence_ratio"].data), 3)
         self.assertEqual(len(run["isi_violations_ratio"].data), 3)
         self.assertEqual(len(run["amplitude_cutoff"].data), 3)
@@ -1492,7 +1476,7 @@ class TestUnitMetricsRoundtrip(TestCase):
         )
         units_region = create_units_region(self.nwbfile)
 
-        run = create_mock_unit_metrics(self.nwbfile, with_obs_intervals=True)
+        run = create_mock_unit_metrics(self.nwbfile)
 
         extensions = SpikeSortingExtensions(name="extensions")
         extensions.add_unit_metrics(run)
@@ -1526,10 +1510,80 @@ class TestUnitMetricsRoundtrip(TestCase):
             np.testing.assert_array_almost_equal(
                 read_run["isi_violations_ratio"][:], run["isi_violations_ratio"].data
             )
-            # obs_intervals round-trip: VectorIndex view gives cumulative, target gives flat data
+
+
+class TestValidUnitPeriodsConstructor(TestCase):
+    """Unit tests for ValidUnitPeriods constructor."""
+
+    def test_constructor(self):
+        """Test that ValidUnitPeriods constructor sets values correctly."""
+        nwbfile = set_up_nwbfile()
+        valid_periods = create_mock_valid_unit_periods(nwbfile)
+
+        self.assertEqual(valid_periods.name, "valid_unit_periods")
+        # 3 units * 2 periods each = 6 rows
+        self.assertEqual(len(valid_periods["start_time"].data), 6)
+        self.assertEqual(len(valid_periods["stop_time"].data), 6)
+        self.assertEqual(len(valid_periods["unit"].data), 6)
+
+
+class TestValidUnitPeriodsRoundtrip(TestCase):
+    """Roundtrip test for ValidUnitPeriods."""
+
+    def setUp(self):
+        self.nwbfile = set_up_nwbfile()
+        self.path = "test_valid_unit_periods.nwb"
+
+    def tearDown(self):
+        remove_test_file(self.path)
+
+    def test_roundtrip(self):
+        """Test writing and reading ValidUnitPeriods."""
+        electrodes_region = self.nwbfile.create_electrode_table_region(
+            region=list(range(10)),
+            description="all electrodes",
+        )
+        units_region = create_units_region(self.nwbfile)
+
+        valid_periods = create_mock_valid_unit_periods(self.nwbfile)
+
+        extensions = SpikeSortingExtensions(name="extensions")
+        extensions.valid_unit_periods = valid_periods
+
+        container = SpikeSortingContainer(
+            name="spike_sorting",
+            sampling_frequency=30000.0,
+            electrodes=electrodes_region,
+            units_region=units_region,
+        )
+        container.spike_sorting_extensions = extensions
+
+        ecephys_module = self.nwbfile.create_processing_module(
+            name="ecephys",
+            description="Extracellular electrophysiology processing",
+        )
+        ecephys_module.add(container)
+
+        with NWBHDF5IO(self.path, mode="w") as io:
+            io.write(self.nwbfile)
+
+        with NWBHDF5IO(self.path, mode="r", load_namespaces=True) as io:
+            read_nwbfile = io.read()
+            read_container = read_nwbfile.processing["ecephys"]["spike_sorting"]
+            read_extensions = read_container.spike_sorting_extensions
+            read_valid_periods = read_extensions.valid_unit_periods
+
+            np.testing.assert_array_almost_equal(
+                read_valid_periods["start_time"][:],
+                valid_periods["start_time"].data,
+            )
+            np.testing.assert_array_almost_equal(
+                read_valid_periods["stop_time"][:],
+                valid_periods["stop_time"].data,
+            )
             np.testing.assert_array_equal(
-                read_run["obs_intervals"].target.data[:],
-                run["obs_intervals"].target.data,
+                read_valid_periods["unit"].data[:],
+                valid_periods["unit"].data,
             )
 
 

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -1369,8 +1369,11 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
             )
 
 
-def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3):
-    """Create a mock UnitMetrics with plain (untyped) VectorData metric columns."""
+def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_obs_intervals: bool = True):
+    """Create a mock UnitMetrics with plain VectorData metric columns.
+
+    Optionally adds a ragged obs_intervals column with two windows per unit.
+    """
     unit_column = DynamicTableRegion(
         name="unit",
         data=list(range(num_units)),
@@ -1400,6 +1403,29 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3):
             data=cutoff_data,
         ),
     ]
+
+    if with_obs_intervals:
+        flat = []
+        cumulative = []
+        running = 0
+        for unit_index in range(num_units):
+            flat.append([unit_index * 10.0, unit_index * 10.0 + 2.0])
+            flat.append([unit_index * 10.0 + 3.0, unit_index * 10.0 + 4.5])
+            running += 2
+            cumulative.append(running)
+
+        obs_intervals_vd = VectorData(
+            name="obs_intervals",
+            data=np.array(flat, dtype=np.float64),
+            description="Per-unit observation intervals (start, stop) in seconds.",
+        )
+        obs_intervals_idx = VectorIndex(
+            name="obs_intervals_index",
+            data=np.array(cumulative, dtype=np.int64),
+            target=obs_intervals_vd,
+        )
+        columns.append(obs_intervals_vd)
+        columns.append(obs_intervals_idx)
 
     return UnitMetrics(
         name="quality_metrics",
@@ -1444,18 +1470,28 @@ def create_mock_valid_unit_periods(nwbfile: NWBFile, num_units: int = 3, periods
 class TestUnitMetricsConstructor(TestCase):
     """Unit tests for UnitMetrics constructor."""
 
-    def test_constructor(self):
+    def test_constructor_without_intervals(self):
         """UnitMetrics is constructed with the expected columns."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile)
+        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=False)
 
         self.assertEqual(run.name, "quality_metrics")
         self.assertIn("presence_ratio", run.colnames)
         self.assertIn("isi_violations_ratio", run.colnames)
         self.assertIn("unit", run.colnames)
+        self.assertNotIn("obs_intervals", run.colnames)
         self.assertEqual(len(run["presence_ratio"].data), 3)
         self.assertEqual(len(run["isi_violations_ratio"].data), 3)
         self.assertEqual(len(run["amplitude_cutoff"].data), 3)
+
+    def test_constructor_with_intervals(self):
+        """UnitMetrics carries obs_intervals as a ragged column."""
+        nwbfile = set_up_nwbfile()
+        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=True)
+
+        self.assertIn("obs_intervals", run.colnames)
+        # 3 units * 2 windows => 6 intervals in the flat data
+        self.assertEqual(run["obs_intervals"].target.data.shape, (6, 2))
 
 
 class TestUnitMetricsRoundtrip(TestCase):
@@ -1476,7 +1512,7 @@ class TestUnitMetricsRoundtrip(TestCase):
         )
         units_region = create_units_region(self.nwbfile)
 
-        run = create_mock_unit_metrics(self.nwbfile)
+        run = create_mock_unit_metrics(self.nwbfile, with_obs_intervals=True)
 
         extensions = SpikeSortingExtensions(name="extensions")
         extensions.add_unit_metrics(run)
@@ -1509,6 +1545,10 @@ class TestUnitMetricsRoundtrip(TestCase):
             )
             np.testing.assert_array_almost_equal(
                 read_run["isi_violations_ratio"][:], run["isi_violations_ratio"].data
+            )
+            np.testing.assert_array_equal(
+                read_run["obs_intervals"].target.data[:],
+                run["obs_intervals"].target.data,
             )
 
 

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -23,7 +23,7 @@ from ndx_spikesorting import (
     SpikeLocations,
     PCAProjectionsByChannel,
     PCAProjectionsConcatenated,
-    UnitMetrics,
+    UnitsMetrics,
     ValidUnitPeriods,
     SpikeSortingExtensions,
     SpikeSortingContainer,
@@ -1369,12 +1369,12 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
             )
 
 
-def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_time_support: bool = True):
-    """Create a mock UnitMetrics with MetricVectorData columns.
+def create_mock_units_metrics(nwbfile: NWBFile, num_units: int = 3, with_time_support: bool = True):
+    """Create a mock UnitsMetrics with MetricVectorData columns.
 
     When ``with_time_support`` is True, a ValidUnitPeriods table is also built
     and each metric column gets its time_support attribute set to reference it.
-    Returns (unit_metrics, valid_unit_periods); the second value is None when
+    Returns (units_metrics, valid_unit_periods); the second value is None when
     ``with_time_support`` is False.
     """
     from ndx_spikesorting import MetricVectorData
@@ -1407,12 +1407,12 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_time_sup
         _col("amplitude_cutoff", "Estimated fraction of spikes missed.", cutoff_data),
     ]
 
-    unit_metrics = UnitMetrics(
+    units_metrics = UnitsMetrics(
         name="quality_metrics",
         description="Run-dependent per-unit metrics from one analysis run.",
         columns=columns,
     )
-    return unit_metrics, vup
+    return units_metrics, vup
 
 
 def create_mock_valid_unit_periods(nwbfile: NWBFile, num_units: int = 3, periods_per_unit: int = 2):
@@ -1448,13 +1448,13 @@ def create_mock_valid_unit_periods(nwbfile: NWBFile, num_units: int = 3, periods
     return valid_unit_periods
 
 
-class TestUnitMetricsConstructor(TestCase):
-    """Unit tests for UnitMetrics constructor."""
+class TestUnitsMetricsConstructor(TestCase):
+    """Unit tests for UnitsMetrics constructor."""
 
     def test_constructor_without_intervals(self):
-        """UnitMetrics columns carry no time_support attribute when not requested."""
+        """UnitsMetrics columns carry no time_support attribute when not requested."""
         nwbfile = set_up_nwbfile()
-        run, vup = create_mock_unit_metrics(nwbfile, with_time_support=False)
+        run, vup = create_mock_units_metrics(nwbfile, with_time_support=False)
 
         self.assertEqual(run.name, "quality_metrics")
         self.assertIn("presence_ratio", run.colnames)
@@ -1469,36 +1469,36 @@ class TestUnitMetricsConstructor(TestCase):
     def test_constructor_with_intervals(self):
         """Each metric column references the same ValidUnitPeriods via time_support."""
         nwbfile = set_up_nwbfile()
-        run, vup = create_mock_unit_metrics(nwbfile, with_time_support=True)
+        run, vup = create_mock_units_metrics(nwbfile, with_time_support=True)
 
         self.assertIsNotNone(vup)
         for col_name in ("presence_ratio", "isi_violations_ratio", "amplitude_cutoff"):
             self.assertIs(run[col_name].time_support, vup)
 
 
-class TestUnitMetricsRoundtrip(TestCase):
-    """Roundtrip test for UnitMetrics."""
+class TestUnitsMetricsRoundtrip(TestCase):
+    """Roundtrip test for UnitsMetrics."""
 
     def setUp(self):
         self.nwbfile = set_up_nwbfile()
-        self.path = "test_unit_metrics.nwb"
+        self.path = "test_units_metrics.nwb"
 
     def tearDown(self):
         remove_test_file(self.path)
 
     def test_roundtrip(self):
-        """Test writing and reading a UnitMetrics instance with linked ValidUnitPeriods."""
+        """Test writing and reading a UnitsMetrics instance with linked ValidUnitPeriods."""
         electrodes_region = self.nwbfile.create_electrode_table_region(
             region=list(range(10)),
             description="all electrodes",
         )
         units_region = create_units_region(self.nwbfile)
 
-        run, vup = create_mock_unit_metrics(self.nwbfile, with_time_support=True)
+        run, vup = create_mock_units_metrics(self.nwbfile, with_time_support=True)
 
         extensions = SpikeSortingExtensions(name="extensions")
         extensions.valid_unit_periods = vup
-        extensions.add_unit_metrics(run)
+        extensions.add_units_metrics(run)
 
         container = SpikeSortingContainer(
             name="spike_sorting",
@@ -1521,7 +1521,7 @@ class TestUnitMetricsRoundtrip(TestCase):
             read_nwbfile = io.read()
             read_container = read_nwbfile.processing["ecephys"]["spike_sorting"]
             read_extensions = read_container.spike_sorting_extensions
-            read_run = read_extensions.unit_metrics["quality_metrics"]
+            read_run = read_extensions.units_metrics["quality_metrics"]
 
             np.testing.assert_array_almost_equal(
                 read_run["presence_ratio"][:], run["presence_ratio"].data
@@ -2056,7 +2056,7 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
         """Extensions restored from the NWB file.
 
         Quality, template, and spiketrain metric columns all live on a
-        single UnitMetrics table on disk; the reader uses
+        single UnitsMetrics table on disk; the reader uses
         ``COLUMN_TO_EXTENSION`` to split them back into the right SI
         extensions on read. ``FiringRate`` is the only canonized typed
         column on Units in v1 (additional canonical columns are in
@@ -2168,14 +2168,14 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
             }
             self.assertGreater(len(typed_columns), 0)
 
-    def test_unit_metrics_present(self):
-        """Run-dependent metrics land in a UnitMetrics instance inside extensions."""
+    def test_units_metrics_present(self):
+        """Run-dependent metrics land in a UnitsMetrics instance inside extensions."""
         from pynwb import NWBHDF5IO
 
         with NWBHDF5IO(self.path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
             ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
-            self.assertIn("quality_metrics", ext.unit_metrics)
+            self.assertIn("quality_metrics", ext.units_metrics)
 
     def test_metric_values_roundtrip(self):
         """Reconstructed SI metric extensions hold the same values."""
@@ -2199,7 +2199,7 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
             )
 
     def test_template_metrics_roundtrip(self):
-        """template_metrics columns split out of UnitMetrics into the right SI extension."""
+        """template_metrics columns split out of UnitsMetrics into the right SI extension."""
         sa = self.read_fn(self.path)
 
         original_tm = self.sorting_analyzer.get_extension("template_metrics").get_data()
@@ -2218,7 +2218,7 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
     def test_quality_and_template_metrics_separated_on_read(self):
         """quality_metrics and template_metrics extensions hold disjoint columns post-read.
 
-        Pre-fix, every column on UnitMetrics was funneled into quality_metrics,
+        Pre-fix, every column on UnitsMetrics was funneled into quality_metrics,
         which made template_metrics empty (or absent) and put template columns
         like ``peak_to_trough_duration`` under quality_metrics.
         """
@@ -2264,7 +2264,7 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
         )
 
 
-class TestUnitMetricsTimeSupportLinkRoundtrip(TestCase):
+class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
     """Round-trip the time_support column-attribute link through a SortingAnalyzer.
 
     Exercises three properties that the column-attribute design has to satisfy:
@@ -2308,7 +2308,7 @@ class TestUnitMetricsTimeSupportLinkRoundtrip(TestCase):
             {"quality_metrics": {"periods": self.periods_arr, "metric_names": ["firing_rate", "presence_ratio"]}}
         )
 
-        self.path = "test_unit_metrics_time_support_link.nwb"
+        self.path = "test_units_metrics_time_support_link.nwb"
 
     def tearDown(self):
         remove_test_file(self.path)
@@ -2337,7 +2337,7 @@ class TestUnitMetricsTimeSupportLinkRoundtrip(TestCase):
 
         # In-memory: metric columns carry the link and the standalone table exists.
         ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
-        um = ext.unit_metrics["quality_metrics"]
+        um = ext.units_metrics["quality_metrics"]
         self.assertIsNotNone(um["presence_ratio"].time_support)
         self.assertIsNotNone(ext.valid_unit_periods)
         # No legacy inline column.
@@ -2423,6 +2423,6 @@ class TestUnitMetricsTimeSupportLinkRoundtrip(TestCase):
         add_sorting_analyzer_to_nwbfile(self.sorting_analyzer, nwbfile)
 
         ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
-        um = ext.unit_metrics["quality_metrics"]
+        um = ext.units_metrics["quality_metrics"]
         self.assertIsNone(getattr(um["firing_rate"], "time_support", None))
         self.assertIsNone(ext.valid_unit_periods)

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -23,7 +23,7 @@ from ndx_spikesorting import (
     SpikeLocations,
     PCAProjectionsByChannel,
     PCAProjectionsConcatenated,
-    MetricsRun,
+    UnitMetrics,
     SpikeSortingExtensions,
     SpikeSortingContainer,
 )
@@ -1368,8 +1368,8 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
             )
 
 
-def create_mock_metrics_run(nwbfile: NWBFile, num_units: int = 3, with_valid_intervals: bool = True):
-    """Create a mock MetricsRun with plain (untyped) VectorData metric columns.
+def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_valid_intervals: bool = True):
+    """Create a mock UnitMetrics with plain (untyped) VectorData metric columns.
 
     In v1 no run-dependent metric is canonized as a typed column type (each
     candidate needs multiple attributes to capture cross-pipeline variability;
@@ -1431,20 +1431,20 @@ def create_mock_metrics_run(nwbfile: NWBFile, num_units: int = 3, with_valid_int
         columns.append(valid_intervals_vd)
         columns.append(valid_intervals_idx)
 
-    return MetricsRun(
+    return UnitMetrics(
         name="quality_metrics",
         description="Run-dependent per-unit metrics from one analysis run.",
         columns=columns,
     )
 
 
-class TestMetricsRunConstructor(TestCase):
-    """Unit tests for MetricsRun constructor."""
+class TestUnitMetricsConstructor(TestCase):
+    """Unit tests for UnitMetrics constructor."""
 
     def test_constructor_without_intervals(self):
-        """MetricsRun is constructed with typed metric columns."""
+        """UnitMetrics is constructed with typed metric columns."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_metrics_run(nwbfile, with_valid_intervals=False)
+        run = create_mock_unit_metrics(nwbfile, with_valid_intervals=False)
 
         self.assertEqual(run.name, "quality_metrics")
         self.assertIn("presence_ratio", run.colnames)
@@ -1455,18 +1455,18 @@ class TestMetricsRunConstructor(TestCase):
         self.assertEqual(len(run["presence_ratio"].data), 3)
 
     def test_constructor_with_intervals(self):
-        """MetricsRun carries valid_intervals as a ragged column."""
+        """UnitMetrics carries valid_intervals as a ragged column."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_metrics_run(nwbfile, with_valid_intervals=True)
+        run = create_mock_unit_metrics(nwbfile, with_valid_intervals=True)
 
         self.assertIn("valid_intervals", run.colnames)
         # 3 units * 2 windows => 6 intervals in the flat data
         self.assertEqual(run["valid_intervals"].target.data.shape, (6, 2))
 
     def test_plain_column_values(self):
-        """MetricsRun stores run-dependent metrics as plain VectorData (v1)."""
+        """UnitMetrics stores run-dependent metrics as plain VectorData (v1)."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_metrics_run(nwbfile, with_valid_intervals=False)
+        run = create_mock_unit_metrics(nwbfile, with_valid_intervals=False)
 
         # No typed-column attributes in v1; columns are plain VectorData.
         self.assertEqual(len(run["presence_ratio"].data), 3)
@@ -1474,28 +1474,28 @@ class TestMetricsRunConstructor(TestCase):
         self.assertEqual(len(run["amplitude_cutoff"].data), 3)
 
 
-class TestMetricsRunRoundtrip(TestCase):
-    """Roundtrip test for MetricsRun."""
+class TestUnitMetricsRoundtrip(TestCase):
+    """Roundtrip test for UnitMetrics."""
 
     def setUp(self):
         self.nwbfile = set_up_nwbfile()
-        self.path = "test_metrics_run.nwb"
+        self.path = "test_unit_metrics.nwb"
 
     def tearDown(self):
         remove_test_file(self.path)
 
     def test_roundtrip(self):
-        """Test writing and reading a MetricsRun instance."""
+        """Test writing and reading a UnitMetrics instance."""
         electrodes_region = self.nwbfile.create_electrode_table_region(
             region=list(range(10)),
             description="all electrodes",
         )
         units_region = create_units_region(self.nwbfile)
 
-        run = create_mock_metrics_run(self.nwbfile, with_valid_intervals=True)
+        run = create_mock_unit_metrics(self.nwbfile, with_valid_intervals=True)
 
         extensions = SpikeSortingExtensions(name="extensions")
-        extensions.add_metrics_runs(run)
+        extensions.add_unit_metrics(run)
 
         container = SpikeSortingContainer(
             name="spike_sorting",
@@ -1518,7 +1518,7 @@ class TestMetricsRunRoundtrip(TestCase):
             read_nwbfile = io.read()
             read_container = read_nwbfile.processing["ecephys"]["spike_sorting"]
             read_extensions = read_container.spike_sorting_extensions
-            read_run = read_extensions.metrics_runs["quality_metrics"]
+            read_run = read_extensions.unit_metrics["quality_metrics"]
 
             np.testing.assert_array_almost_equal(
                 read_run["presence_ratio"][:], run["presence_ratio"].data
@@ -1975,7 +1975,7 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
         """Extensions restored from the NWB file.
 
         v1 canonizes one typed column (FiringRate) on Units and writes
-        quality_metrics to MetricsRun as plain VectorData. template_metrics
+        quality_metrics to UnitMetrics as plain VectorData. template_metrics
         columns are not yet typed and are not currently round-tripped;
         follow-up PRs will canonize the remaining cell-intrinsic columns
         (peak_to_trough_duration, trough_half_width) and re-enable template
@@ -2087,14 +2087,14 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
             }
             self.assertGreater(len(typed_columns), 0)
 
-    def test_metrics_run_present(self):
-        """Run-dependent metrics land in a MetricsRun instance inside extensions."""
+    def test_unit_metrics_present(self):
+        """Run-dependent metrics land in a UnitMetrics instance inside extensions."""
         from pynwb import NWBHDF5IO
 
         with NWBHDF5IO(self.path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
             ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
-            self.assertIn("quality_metrics", ext.metrics_runs)
+            self.assertIn("quality_metrics", ext.unit_metrics)
 
     def test_metric_values_roundtrip(self):
         """Reconstructed SI metric extensions hold the same values."""

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -1369,10 +1369,10 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
             )
 
 
-def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_obs_intervals: bool = True):
+def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_computation_intervals: bool = True):
     """Create a mock UnitMetrics with plain VectorData metric columns.
 
-    Optionally adds a ragged obs_intervals column with two windows per unit.
+    Optionally adds a ragged computation_intervals column with two windows per unit.
     """
     unit_column = DynamicTableRegion(
         name="unit",
@@ -1404,7 +1404,7 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_obs_inte
         ),
     ]
 
-    if with_obs_intervals:
+    if with_computation_intervals:
         flat = []
         cumulative = []
         running = 0
@@ -1414,18 +1414,18 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_obs_inte
             running += 2
             cumulative.append(running)
 
-        obs_intervals_vd = VectorData(
-            name="obs_intervals",
+        computation_intervals_vd = VectorData(
+            name="computation_intervals",
             data=np.array(flat, dtype=np.float64),
-            description="Per-unit observation intervals (start, stop) in seconds.",
+            description="Per-unit time intervals (start, stop) in seconds over which metrics were computed.",
         )
-        obs_intervals_idx = VectorIndex(
-            name="obs_intervals_index",
+        computation_intervals_idx = VectorIndex(
+            name="computation_intervals_index",
             data=np.array(cumulative, dtype=np.int64),
-            target=obs_intervals_vd,
+            target=computation_intervals_vd,
         )
-        columns.append(obs_intervals_vd)
-        columns.append(obs_intervals_idx)
+        columns.append(computation_intervals_vd)
+        columns.append(computation_intervals_idx)
 
     return UnitMetrics(
         name="quality_metrics",
@@ -1473,25 +1473,25 @@ class TestUnitMetricsConstructor(TestCase):
     def test_constructor_without_intervals(self):
         """UnitMetrics is constructed with the expected columns."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=False)
+        run = create_mock_unit_metrics(nwbfile, with_computation_intervals=False)
 
         self.assertEqual(run.name, "quality_metrics")
         self.assertIn("presence_ratio", run.colnames)
         self.assertIn("isi_violations_ratio", run.colnames)
         self.assertIn("unit", run.colnames)
-        self.assertNotIn("obs_intervals", run.colnames)
+        self.assertNotIn("computation_intervals", run.colnames)
         self.assertEqual(len(run["presence_ratio"].data), 3)
         self.assertEqual(len(run["isi_violations_ratio"].data), 3)
         self.assertEqual(len(run["amplitude_cutoff"].data), 3)
 
     def test_constructor_with_intervals(self):
-        """UnitMetrics carries obs_intervals as a ragged column."""
+        """UnitMetrics carries computation_intervals as a ragged column."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=True)
+        run = create_mock_unit_metrics(nwbfile, with_computation_intervals=True)
 
-        self.assertIn("obs_intervals", run.colnames)
+        self.assertIn("computation_intervals", run.colnames)
         # 3 units * 2 windows => 6 intervals in the flat data
-        self.assertEqual(run["obs_intervals"].target.data.shape, (6, 2))
+        self.assertEqual(run["computation_intervals"].target.data.shape, (6, 2))
 
 
 class TestUnitMetricsRoundtrip(TestCase):
@@ -1512,7 +1512,7 @@ class TestUnitMetricsRoundtrip(TestCase):
         )
         units_region = create_units_region(self.nwbfile)
 
-        run = create_mock_unit_metrics(self.nwbfile, with_obs_intervals=True)
+        run = create_mock_unit_metrics(self.nwbfile, with_computation_intervals=True)
 
         extensions = SpikeSortingExtensions(name="extensions")
         extensions.add_unit_metrics(run)
@@ -1547,8 +1547,8 @@ class TestUnitMetricsRoundtrip(TestCase):
                 read_run["isi_violations_ratio"][:], run["isi_violations_ratio"].data
             )
             np.testing.assert_array_equal(
-                read_run["obs_intervals"].target.data[:],
-                run["obs_intervals"].target.data,
+                read_run["computation_intervals"].target.data[:],
+                run["computation_intervals"].target.data,
             )
 
 

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -1370,14 +1370,14 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
 
 
 def create_mock_units_metrics(nwbfile: NWBFile, num_units: int = 3, with_time_support: bool = True):
-    """Create a mock UnitsMetrics with MetricVectorData columns.
+    """Create a mock UnitsMetrics with UnitVectorData columns.
 
     When ``with_time_support`` is True, a ValidUnitPeriods table is also built
     and each metric column gets its time_support attribute set to reference it.
     Returns (units_metrics, valid_unit_periods); the second value is None when
     ``with_time_support`` is False.
     """
-    from ndx_spikesorting import MetricVectorData
+    from ndx_spikesorting import UnitVectorData
 
     unit_column = DynamicTableRegion(
         name="unit",
@@ -1398,7 +1398,7 @@ def create_mock_units_metrics(nwbfile: NWBFile, num_units: int = 3, with_time_su
         kwargs = dict(name=name, description=description, data=data)
         if vup is not None:
             kwargs["time_support"] = vup
-        return MetricVectorData(**kwargs)
+        return UnitVectorData(**kwargs)
 
     columns = [
         unit_column,
@@ -1497,7 +1497,7 @@ class TestUnitsMetricsRoundtrip(TestCase):
         run, vup = create_mock_units_metrics(self.nwbfile, with_time_support=True)
 
         extensions = SpikeSortingExtensions(name="extensions")
-        extensions.valid_unit_periods = vup
+        extensions.add_valid_unit_periods(vup)
         extensions.add_units_metrics(run)
 
         container = SpikeSortingContainer(
@@ -1575,7 +1575,7 @@ class TestValidUnitPeriodsRoundtrip(TestCase):
         valid_periods = create_mock_valid_unit_periods(self.nwbfile)
 
         extensions = SpikeSortingExtensions(name="extensions")
-        extensions.valid_unit_periods = valid_periods
+        extensions.add_valid_unit_periods(valid_periods)
 
         container = SpikeSortingContainer(
             name="spike_sorting",
@@ -1598,7 +1598,7 @@ class TestValidUnitPeriodsRoundtrip(TestCase):
             read_nwbfile = io.read()
             read_container = read_nwbfile.processing["ecephys"]["spike_sorting"]
             read_extensions = read_container.spike_sorting_extensions
-            read_valid_periods = read_extensions.valid_unit_periods
+            read_valid_periods = read_extensions.valid_unit_periods["valid_unit_periods"]
 
             np.testing.assert_array_almost_equal(
                 read_valid_periods["start_time"][:],
@@ -2425,4 +2425,100 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
         ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
         um = ext.units_metrics["quality_metrics"]
         self.assertIsNone(getattr(um["firing_rate"], "time_support", None))
-        self.assertIsNone(ext.valid_unit_periods)
+        self.assertEqual(len(ext.valid_unit_periods), 0)
+
+    def test_qm_periods_without_si_extension_writes_plain_time_intervals(self):
+        """qm.params['periods'] set, no SI valid_unit_periods → plain TimeIntervals, no ValidUnitPeriods."""
+        from ndx_spikesorting import add_sorting_analyzer_to_nwbfile, read_sorting_analyzer_from_nwb
+
+        # Re-compute quality_metrics with custom periods (no SI valid_unit_periods extension).
+        self.sorting_analyzer.compute(
+            {"quality_metrics": {
+                "periods": self.periods_arr,
+                "metric_names": ["firing_rate", "presence_ratio"],
+                "delete_existing_metrics": True,
+            }}
+        )
+
+        nwbfile = self._build_nwbfile()
+        add_sorting_analyzer_to_nwbfile(self.sorting_analyzer, nwbfile)
+
+        ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
+        self.assertEqual(len(ext.valid_unit_periods), 0)
+        self.assertEqual(len(ext.time_intervals), 1)
+        self.assertIn("quality_metrics_time_support", ext.time_intervals)
+
+        um = ext.units_metrics["quality_metrics"]
+        ts = um["firing_rate"].time_support
+        self.assertIsNotNone(ts)
+        # Should NOT be a ValidUnitPeriods (no SI extension); should be a plain TimeIntervals.
+        from ndx_spikesorting import ValidUnitPeriods
+        self.assertNotIsInstance(ts, ValidUnitPeriods)
+
+        with NWBHDF5IO(self.path, "w") as io:
+            io.write(nwbfile)
+        sa2 = read_sorting_analyzer_from_nwb(self.path)
+        p2 = sa2.get_extension("quality_metrics").params.get("periods")
+        self.assertIsNotNone(p2)
+        self.assertEqual(len(p2), len(self.periods_arr))
+
+    def test_supports_periods_filter_excludes_non_period_metrics(self):
+        """Metrics with supports_periods=False (e.g. snr) don't get a time_support link."""
+        from ndx_spikesorting import add_sorting_analyzer_to_nwbfile
+
+        # Recompute qm with a mix: firing_rate (supports_periods=True), snr (False).
+        self.sorting_analyzer.compute(
+            {"quality_metrics": {
+                "periods": self.periods_arr,
+                "metric_names": ["firing_rate", "snr"],
+                "delete_existing_metrics": True,
+            }}
+        )
+
+        nwbfile = self._build_nwbfile()
+        add_sorting_analyzer_to_nwbfile(self.sorting_analyzer, nwbfile)
+
+        ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
+        um = ext.units_metrics["quality_metrics"]
+
+        # firing_rate should have a time_support link (supports_periods=True)
+        self.assertIsNotNone(um["firing_rate"].time_support)
+        # snr should not (supports_periods=False — value doesn't depend on periods)
+        self.assertIsNone(um["snr"].time_support)
+
+    def test_diverging_qm_periods_and_si_extension_write_both_tables(self):
+        """qm has different periods than SI ext → both tables written; columns link to qm-derived."""
+        from ndx_spikesorting import add_sorting_analyzer_to_nwbfile
+
+        fs = self.sorting_analyzer.sampling_frequency
+        # SI extension with one set of windows
+        si_periods = np.array(
+            [(0, 0, int(2.0 * fs), u) for u in range(3)], dtype=self.unit_period_dtype
+        )
+        self.sorting_analyzer.compute({"valid_unit_periods": {
+            "method": "user_defined",
+            "user_defined_periods": si_periods,
+            "minimum_valid_period_duration": 0,
+        }})
+        # qm with DIFFERENT periods (covers more of the recording)
+        qm_periods = np.array(
+            [(0, 0, int(4.5 * fs), u) for u in range(3)], dtype=self.unit_period_dtype
+        )
+        self.sorting_analyzer.compute({"quality_metrics": {
+            "periods": qm_periods,
+            "metric_names": ["firing_rate"],
+            "delete_existing_metrics": True,
+        }})
+
+        nwbfile = self._build_nwbfile()
+        add_sorting_analyzer_to_nwbfile(self.sorting_analyzer, nwbfile)
+
+        ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
+        # Both tables written
+        self.assertEqual(len(ext.valid_unit_periods), 1)
+        self.assertEqual(len(ext.time_intervals), 1)
+
+        # Metric column links to the qm-derived TimeIntervals, not the ValidUnitPeriods
+        um = ext.units_metrics["quality_metrics"]
+        from ndx_spikesorting import ValidUnitPeriods
+        self.assertNotIsInstance(um["firing_rate"].time_support, ValidUnitPeriods)

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -1370,10 +1370,15 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
 
 
 def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_time_support: bool = True):
-    """Create a mock UnitMetrics with plain VectorData metric columns.
+    """Create a mock UnitMetrics with MetricVectorData columns.
 
-    Optionally adds a ragged time_support column with two windows per unit.
+    When ``with_time_support`` is True, a ValidUnitPeriods table is also built
+    and each metric column gets its time_support attribute set to reference it.
+    Returns (unit_metrics, valid_unit_periods); the second value is None when
+    ``with_time_support`` is False.
     """
+    from ndx_spikesorting import MetricVectorData
+
     unit_column = DynamicTableRegion(
         name="unit",
         data=list(range(num_units)),
@@ -1381,57 +1386,33 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_time_sup
         table=nwbfile.units,
     )
 
+    vup = None
+    if with_time_support:
+        vup = create_mock_valid_unit_periods(nwbfile, num_units=num_units, periods_per_unit=2)
+
     presence_data = np.random.rand(num_units)
     isi_data = np.random.rand(num_units) * 0.1
     cutoff_data = np.random.rand(num_units) * 0.2
 
+    def _col(name, description, data):
+        kwargs = dict(name=name, description=description, data=data)
+        if vup is not None:
+            kwargs["time_support"] = vup
+        return MetricVectorData(**kwargs)
+
     columns = [
         unit_column,
-        VectorData(
-            name="presence_ratio",
-            description="Fraction of bins in which the unit fired.",
-            data=presence_data,
-        ),
-        VectorData(
-            name="isi_violations_ratio",
-            description="Fraction of ISIs below the refractory threshold.",
-            data=isi_data,
-        ),
-        VectorData(
-            name="amplitude_cutoff",
-            description="Estimated fraction of spikes missed.",
-            data=cutoff_data,
-        ),
+        _col("presence_ratio", "Fraction of bins in which the unit fired.", presence_data),
+        _col("isi_violations_ratio", "Fraction of ISIs below the refractory threshold.", isi_data),
+        _col("amplitude_cutoff", "Estimated fraction of spikes missed.", cutoff_data),
     ]
 
-    if with_time_support:
-        flat = []
-        cumulative = []
-        running = 0
-        for unit_index in range(num_units):
-            flat.append([unit_index * 10.0, unit_index * 10.0 + 2.0])
-            flat.append([unit_index * 10.0 + 3.0, unit_index * 10.0 + 4.5])
-            running += 2
-            cumulative.append(running)
-
-        time_support_vd = VectorData(
-            name="time_support",
-            data=np.array(flat, dtype=np.float64),
-            description="Per-unit time intervals (start, stop) in seconds over which metrics were computed.",
-        )
-        time_support_idx = VectorIndex(
-            name="time_support_index",
-            data=np.array(cumulative, dtype=np.int64),
-            target=time_support_vd,
-        )
-        columns.append(time_support_vd)
-        columns.append(time_support_idx)
-
-    return UnitMetrics(
+    unit_metrics = UnitMetrics(
         name="quality_metrics",
         description="Run-dependent per-unit metrics from one analysis run.",
         columns=columns,
     )
+    return unit_metrics, vup
 
 
 def create_mock_valid_unit_periods(nwbfile: NWBFile, num_units: int = 3, periods_per_unit: int = 2):
@@ -1471,27 +1452,28 @@ class TestUnitMetricsConstructor(TestCase):
     """Unit tests for UnitMetrics constructor."""
 
     def test_constructor_without_intervals(self):
-        """UnitMetrics is constructed with the expected columns."""
+        """UnitMetrics columns carry no time_support attribute when not requested."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_time_support=False)
+        run, vup = create_mock_unit_metrics(nwbfile, with_time_support=False)
 
         self.assertEqual(run.name, "quality_metrics")
         self.assertIn("presence_ratio", run.colnames)
         self.assertIn("isi_violations_ratio", run.colnames)
         self.assertIn("unit", run.colnames)
-        self.assertNotIn("time_support", run.colnames)
+        self.assertIsNone(vup)
+        self.assertIsNone(getattr(run["presence_ratio"], "time_support", None))
         self.assertEqual(len(run["presence_ratio"].data), 3)
         self.assertEqual(len(run["isi_violations_ratio"].data), 3)
         self.assertEqual(len(run["amplitude_cutoff"].data), 3)
 
     def test_constructor_with_intervals(self):
-        """UnitMetrics carries time_support as a ragged column."""
+        """Each metric column references the same ValidUnitPeriods via time_support."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_time_support=True)
+        run, vup = create_mock_unit_metrics(nwbfile, with_time_support=True)
 
-        self.assertIn("time_support", run.colnames)
-        # 3 units * 2 windows => 6 intervals in the flat data
-        self.assertEqual(run["time_support"].target.data.shape, (6, 2))
+        self.assertIsNotNone(vup)
+        for col_name in ("presence_ratio", "isi_violations_ratio", "amplitude_cutoff"):
+            self.assertIs(run[col_name].time_support, vup)
 
 
 class TestUnitMetricsRoundtrip(TestCase):
@@ -1505,16 +1487,17 @@ class TestUnitMetricsRoundtrip(TestCase):
         remove_test_file(self.path)
 
     def test_roundtrip(self):
-        """Test writing and reading a UnitMetrics instance."""
+        """Test writing and reading a UnitMetrics instance with linked ValidUnitPeriods."""
         electrodes_region = self.nwbfile.create_electrode_table_region(
             region=list(range(10)),
             description="all electrodes",
         )
         units_region = create_units_region(self.nwbfile)
 
-        run = create_mock_unit_metrics(self.nwbfile, with_time_support=True)
+        run, vup = create_mock_unit_metrics(self.nwbfile, with_time_support=True)
 
         extensions = SpikeSortingExtensions(name="extensions")
+        extensions.valid_unit_periods = vup
         extensions.add_unit_metrics(run)
 
         container = SpikeSortingContainer(
@@ -1546,9 +1529,13 @@ class TestUnitMetricsRoundtrip(TestCase):
             np.testing.assert_array_almost_equal(
                 read_run["isi_violations_ratio"][:], run["isi_violations_ratio"].data
             )
+            # The link survives the round-trip: each metric column resolves to
+            # the same ValidUnitPeriods table.
+            ts_link = read_run["presence_ratio"].time_support
+            self.assertIsNotNone(ts_link)
             np.testing.assert_array_equal(
-                read_run["time_support"].target.data[:],
-                run["time_support"].target.data,
+                np.asarray(ts_link["start_time"][:]),
+                np.asarray(vup["start_time"].data),
             )
 
 
@@ -2275,3 +2262,167 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
             f"COLUMN_TO_EXTENSION: {uncovered}. Add them to the dict in "
             "src/pynwb/ndx_spikesorting/utils.py.",
         )
+
+
+class TestUnitMetricsTimeSupportLinkRoundtrip(TestCase):
+    """Round-trip the time_support column-attribute link through a SortingAnalyzer.
+
+    Exercises three properties that the column-attribute design has to satisfy:
+    (1) when quality_metrics is computed with ``periods=<array>``, those periods
+    round-trip through a linked ValidUnitPeriods table; (2) the DTR is
+    id-aware, so a permuted nwbfile.units does not corrupt unit assignment;
+    (3) the absence of qm periods is also handled cleanly.
+    """
+
+    def setUp(self):
+        from datetime import datetime, timezone
+
+        from spikeinterface.core import create_sorting_analyzer, generate_ground_truth_recording
+        from spikeinterface.core.base import unit_period_dtype
+        from neuroconv.tools.spikeinterface import add_recording_to_nwbfile, add_sorting_to_nwbfile
+
+        self.unit_period_dtype = unit_period_dtype
+        self.add_recording_to_nwbfile = add_recording_to_nwbfile
+        self.add_sorting_to_nwbfile = add_sorting_to_nwbfile
+        self.datetime, self.timezone = datetime, timezone
+
+        recording, sorting = generate_ground_truth_recording(
+            durations=[5.0], num_units=3, num_channels=8, seed=42
+        )
+        self.recording, self.sorting = recording, sorting
+        self.sorting_analyzer = create_sorting_analyzer(
+            sorting=sorting, recording=recording, format="memory", sparse=True
+        )
+        self.sorting_analyzer.compute(
+            {"random_spikes": {"max_spikes_per_unit": 10, "seed": 42}, "templates": {}, "noise_levels": {}}
+        )
+
+        fs = self.sorting_analyzer.sampling_frequency
+        n_units = len(self.sorting_analyzer.unit_ids)
+        periods = []
+        for u in range(n_units):
+            periods.append((0, int(0.0 * fs), int(1.5 * fs), u))
+            periods.append((0, int(2.0 * fs), int(4.5 * fs), u))
+        self.periods_arr = np.array(periods, dtype=unit_period_dtype)
+        self.sorting_analyzer.compute(
+            {"quality_metrics": {"periods": self.periods_arr, "metric_names": ["firing_rate", "presence_ratio"]}}
+        )
+
+        self.path = "test_unit_metrics_time_support_link.nwb"
+
+    def tearDown(self):
+        remove_test_file(self.path)
+
+    def _build_nwbfile(self, units_unit_ids=None):
+        nwbfile = NWBFile(
+            session_description="t",
+            identifier="t",
+            session_start_time=self.datetime.now(self.timezone.utc),
+        )
+        self.add_recording_to_nwbfile(self.recording, nwbfile=nwbfile, write_as="raw", iterator_type=None)
+        self.add_sorting_to_nwbfile(self.sorting, nwbfile=nwbfile, write_as="units")
+        if units_unit_ids is not None:
+            # Permute the unit_name column to simulate a units table whose row
+            # order does not match the analyzer's unit_ids order.
+            unit_name_col = nwbfile.units["unit_name"]
+            unit_name_col.data[:] = units_unit_ids
+        return nwbfile
+
+    def test_periods_round_trip_via_link(self):
+        """qm periods round-trip to a linked ValidUnitPeriods and back."""
+        from ndx_spikesorting import add_sorting_analyzer_to_nwbfile, read_sorting_analyzer_from_nwb
+
+        nwbfile = self._build_nwbfile()
+        add_sorting_analyzer_to_nwbfile(self.sorting_analyzer, nwbfile)
+
+        # In-memory: metric columns carry the link and the standalone table exists.
+        ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
+        um = ext.unit_metrics["quality_metrics"]
+        self.assertIsNotNone(um["presence_ratio"].time_support)
+        self.assertIsNotNone(ext.valid_unit_periods)
+        # No legacy inline column.
+        self.assertNotIn("time_support", um.colnames)
+
+        with NWBHDF5IO(self.path, "w") as io:
+            io.write(nwbfile)
+        sa2 = read_sorting_analyzer_from_nwb(self.path)
+
+        p2 = sa2.get_extension("quality_metrics").params.get("periods")
+        self.assertIsNotNone(p2)
+        orig_sort = np.sort(self.periods_arr, order=["unit_index", "start_sample_index"])
+        new_sort = np.sort(p2, order=["unit_index", "start_sample_index"])
+        np.testing.assert_array_equal(orig_sort["start_sample_index"], new_sort["start_sample_index"])
+        np.testing.assert_array_equal(orig_sort["end_sample_index"], new_sort["end_sample_index"])
+        np.testing.assert_array_equal(orig_sort["unit_index"], new_sort["unit_index"])
+
+    def test_periods_round_trip_with_permuted_units(self):
+        """A permuted nwbfile.units row order does not corrupt unit assignment.
+
+        After permuting unit_name on the Units table, the id-aware DTR ensures
+        each metric value still ends up associated with the correct unit on
+        round-trip. The qm periods are reconstructed correctly per unit too.
+        """
+        from ndx_spikesorting import add_sorting_analyzer_to_nwbfile, read_sorting_analyzer_from_nwb
+
+        analyzer_ids = [str(u) for u in self.sorting_analyzer.unit_ids]
+        # Reverse the names so row i carries the unit that the analyzer has at
+        # position (n - 1 - i).
+        permuted = list(reversed(analyzer_ids))
+
+        nwbfile = self._build_nwbfile(units_unit_ids=permuted)
+        add_sorting_analyzer_to_nwbfile(self.sorting_analyzer, nwbfile)
+
+        with NWBHDF5IO(self.path, "w") as io:
+            io.write(nwbfile)
+        sa2 = read_sorting_analyzer_from_nwb(self.path)
+
+        # Reconstructed analyzer's unit order follows the on-disk units table,
+        # which is the permuted order. Metric values per unit must match the
+        # original analyzer's, looked up by id rather than position.
+        original_qm = self.sorting_analyzer.get_extension("quality_metrics").get_data()
+        restored_qm = sa2.get_extension("quality_metrics").get_data()
+        for unit_id in original_qm.index:
+            uid = str(unit_id)
+            self.assertIn(uid, restored_qm.index.astype(str).tolist())
+            for col in ("firing_rate", "presence_ratio"):
+                if col not in restored_qm.columns:
+                    continue
+                expected = original_qm.loc[unit_id, col]
+                got = restored_qm.loc[uid, col] if uid in restored_qm.index else restored_qm.loc[unit_id, col]
+                if not np.isnan(expected):
+                    self.assertAlmostEqual(expected, got, places=5)
+
+        # Periods come back with correct unit positions relative to the
+        # reconstructed analyzer.
+        p2 = sa2.get_extension("quality_metrics").params.get("periods")
+        self.assertIsNotNone(p2)
+        # Reverse-map: for each restored period, the analyzer-position must
+        # round-trip to the same unit id as the original.
+        restored_unit_ids_by_pos = list(sa2.unit_ids)
+        for p_orig in self.periods_arr:
+            orig_uid = analyzer_ids[int(p_orig["unit_index"])]
+            # Find any matching period in restored: same start/end, unit id matches.
+            mask = (
+                (p2["start_sample_index"] == int(p_orig["start_sample_index"]))
+                & (p2["end_sample_index"] == int(p_orig["end_sample_index"]))
+            )
+            candidate_positions = p2["unit_index"][mask]
+            candidate_uids = {restored_unit_ids_by_pos[int(pos)] for pos in candidate_positions}
+            self.assertIn(orig_uid, candidate_uids)
+
+    def test_no_qm_periods_leaves_no_link(self):
+        """When qm has no periods, no ValidUnitPeriods is written and no link is set."""
+        from ndx_spikesorting import add_sorting_analyzer_to_nwbfile
+
+        # Re-compute quality_metrics without periods.
+        self.sorting_analyzer.compute(
+            {"quality_metrics": {"metric_names": ["firing_rate"], "delete_existing_metrics": True}}
+        )
+
+        nwbfile = self._build_nwbfile()
+        add_sorting_analyzer_to_nwbfile(self.sorting_analyzer, nwbfile)
+
+        ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
+        um = ext.unit_metrics["quality_metrics"]
+        self.assertIsNone(getattr(um["firing_rate"], "time_support", None))
+        self.assertIsNone(ext.valid_unit_periods)

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -23,7 +23,7 @@ from ndx_spikesorting import (
     SpikeLocations,
     PCAProjectionsByChannel,
     PCAProjectionsConcatenated,
-    ValidUnitPeriods,
+    MetricsRun,
     SpikeSortingExtensions,
     SpikeSortingContainer,
 )
@@ -1368,76 +1368,134 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
             )
 
 
-def create_mock_valid_unit_periods(nwbfile: NWBFile, num_units: int = 3, periods_per_unit: int = 2):
-    """Create mock ValidUnitPeriods with time intervals for each unit."""
-    start_times = []
-    stop_times = []
-    unit_indices = []
+def create_mock_metrics_run(nwbfile: NWBFile, num_units: int = 3, with_valid_intervals: bool = True):
+    """Create a mock MetricsRun with plain (untyped) VectorData metric columns.
 
-    for unit_idx in range(num_units):
-        for p in range(periods_per_unit):
-            start = unit_idx * 10.0 + p * 3.0
-            stop = start + 2.0
-            start_times.append(start)
-            stop_times.append(stop)
-            unit_indices.append(unit_idx)
-
-    units = DynamicTableRegion(
+    In v1 no run-dependent metric is canonized as a typed column type (each
+    candidate needs multiple attributes to capture cross-pipeline variability;
+    see canonical_unit_columns.md in the vault). Columns are stored as plain
+    VectorData with their SI metric names preserved. Optionally adds a ragged
+    valid_intervals column with two windows per unit.
+    """
+    unit_column = DynamicTableRegion(
         name="unit",
-        data=unit_indices,
-        description="Reference to units table for each valid period.",
+        data=list(range(num_units)),
+        description="Reference to nwbfile.units row this metric value applies to.",
         table=nwbfile.units,
     )
 
-    valid_unit_periods = ValidUnitPeriods(
-        name="valid_unit_periods",
-        description="Valid periods for each unit.",
-        columns=[
-            VectorData(name="start_time", data=start_times, description="Start time of each valid period."),
-            VectorData(name="stop_time", data=stop_times, description="Stop time of each valid period."),
-            units,
-        ],
+    presence_data = np.random.rand(num_units)
+    isi_data = np.random.rand(num_units) * 0.1
+    cutoff_data = np.random.rand(num_units) * 0.2
+
+    columns = [
+        unit_column,
+        VectorData(
+            name="presence_ratio",
+            description="Fraction of bins in which the unit fired (plain column; not canonized).",
+            data=presence_data,
+        ),
+        VectorData(
+            name="isi_violations_ratio",
+            description="Fraction of ISIs below the refractory threshold (plain column; not canonized).",
+            data=isi_data,
+        ),
+        VectorData(
+            name="amplitude_cutoff",
+            description="Estimated fraction of spikes missed (plain column; not canonized).",
+            data=cutoff_data,
+        ),
+    ]
+
+    if with_valid_intervals:
+        # Two disjoint windows per unit
+        flat = []
+        cumulative = []
+        running = 0
+        for unit_idx in range(num_units):
+            flat.append([unit_idx * 10.0, unit_idx * 10.0 + 2.0])
+            flat.append([unit_idx * 10.0 + 3.0, unit_idx * 10.0 + 4.5])
+            running += 2
+            cumulative.append(running)
+
+        valid_intervals_vd = VectorData(
+            name="valid_intervals",
+            data=np.array(flat, dtype=np.float64),
+            description="Per-unit observation intervals (start, stop) in seconds.",
+        )
+        valid_intervals_idx = VectorIndex(
+            name="valid_intervals_index",
+            data=np.array(cumulative, dtype=np.int64),
+            target=valid_intervals_vd,
+        )
+        columns.append(valid_intervals_vd)
+        columns.append(valid_intervals_idx)
+
+    return MetricsRun(
+        name="quality_metrics",
+        description="Run-dependent per-unit metrics from one analysis run.",
+        columns=columns,
     )
-    return valid_unit_periods
 
 
-class TestValidUnitPeriodsConstructor(TestCase):
-    """Unit tests for ValidUnitPeriods constructor."""
+class TestMetricsRunConstructor(TestCase):
+    """Unit tests for MetricsRun constructor."""
 
-    def test_constructor(self):
-        """Test that ValidUnitPeriods constructor sets values correctly."""
+    def test_constructor_without_intervals(self):
+        """MetricsRun is constructed with typed metric columns."""
         nwbfile = set_up_nwbfile()
-        valid_periods = create_mock_valid_unit_periods(nwbfile)
+        run = create_mock_metrics_run(nwbfile, with_valid_intervals=False)
 
-        self.assertEqual(valid_periods.name, "valid_unit_periods")
-        # 3 units * 2 periods each = 6 rows
-        self.assertEqual(len(valid_periods["start_time"].data), 6)
-        self.assertEqual(len(valid_periods["stop_time"].data), 6)
-        self.assertEqual(len(valid_periods["unit"].data), 6)
+        self.assertEqual(run.name, "quality_metrics")
+        self.assertIn("presence_ratio", run.colnames)
+        self.assertIn("isi_violations_ratio", run.colnames)
+        self.assertIn("unit", run.colnames)
+        self.assertNotIn("valid_intervals", run.colnames)
+        # 3 units => 3 rows
+        self.assertEqual(len(run["presence_ratio"].data), 3)
+
+    def test_constructor_with_intervals(self):
+        """MetricsRun carries valid_intervals as a ragged column."""
+        nwbfile = set_up_nwbfile()
+        run = create_mock_metrics_run(nwbfile, with_valid_intervals=True)
+
+        self.assertIn("valid_intervals", run.colnames)
+        # 3 units * 2 windows => 6 intervals in the flat data
+        self.assertEqual(run["valid_intervals"].target.data.shape, (6, 2))
+
+    def test_plain_column_values(self):
+        """MetricsRun stores run-dependent metrics as plain VectorData (v1)."""
+        nwbfile = set_up_nwbfile()
+        run = create_mock_metrics_run(nwbfile, with_valid_intervals=False)
+
+        # No typed-column attributes in v1; columns are plain VectorData.
+        self.assertEqual(len(run["presence_ratio"].data), 3)
+        self.assertEqual(len(run["isi_violations_ratio"].data), 3)
+        self.assertEqual(len(run["amplitude_cutoff"].data), 3)
 
 
-class TestValidUnitPeriodsRoundtrip(TestCase):
-    """Roundtrip test for ValidUnitPeriods."""
+class TestMetricsRunRoundtrip(TestCase):
+    """Roundtrip test for MetricsRun."""
 
     def setUp(self):
         self.nwbfile = set_up_nwbfile()
-        self.path = "test_valid_unit_periods.nwb"
+        self.path = "test_metrics_run.nwb"
 
     def tearDown(self):
         remove_test_file(self.path)
 
     def test_roundtrip(self):
-        """Test writing and reading ValidUnitPeriods."""
+        """Test writing and reading a MetricsRun instance."""
         electrodes_region = self.nwbfile.create_electrode_table_region(
             region=list(range(10)),
             description="all electrodes",
         )
         units_region = create_units_region(self.nwbfile)
 
-        valid_periods = create_mock_valid_unit_periods(self.nwbfile)
+        run = create_mock_metrics_run(self.nwbfile, with_valid_intervals=True)
 
         extensions = SpikeSortingExtensions(name="extensions")
-        extensions.valid_unit_periods = valid_periods
+        extensions.add_metrics_runs(run)
 
         container = SpikeSortingContainer(
             name="spike_sorting",
@@ -1460,19 +1518,18 @@ class TestValidUnitPeriodsRoundtrip(TestCase):
             read_nwbfile = io.read()
             read_container = read_nwbfile.processing["ecephys"]["spike_sorting"]
             read_extensions = read_container.spike_sorting_extensions
-            read_valid_periods = read_extensions.valid_unit_periods
+            read_run = read_extensions.metrics_runs["quality_metrics"]
 
             np.testing.assert_array_almost_equal(
-                read_valid_periods["start_time"][:],
-                valid_periods["start_time"].data,
+                read_run["presence_ratio"][:], run["presence_ratio"].data
             )
             np.testing.assert_array_almost_equal(
-                read_valid_periods["stop_time"][:],
-                valid_periods["stop_time"].data,
+                read_run["isi_violations_ratio"][:], run["isi_violations_ratio"].data
             )
+            # valid_intervals round-trip: VectorIndex view gives cumulative, target gives flat data
             np.testing.assert_array_equal(
-                read_valid_periods["unit"].data[:],
-                valid_periods["unit"].data,
+                read_run["valid_intervals"].target.data[:],
+                run["valid_intervals"].target.data,
             )
 
 
@@ -1763,6 +1820,9 @@ def _create_sorting_analyzer(compute_all: bool = True):
                 "spike_amplitudes": {},
                 "amplitude_scalings": {},
                 "spike_locations": {"method": "grid_convolution"},
+                "quality_metrics": {},
+                "template_metrics": {},
+                "spiketrain_metrics": {},
             }
         )
     return sorting_analyzer, recording, sorting
@@ -1912,13 +1972,22 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
         remove_test_file(self.path)
 
     def test_loads_all_extensions(self):
-        """All 12 extensions are restored from the NWB file."""
+        """Extensions restored from the NWB file.
+
+        v1 canonizes one typed column (FiringRate) on Units and writes
+        quality_metrics to MetricsRun as plain VectorData. template_metrics
+        columns are not yet typed and are not currently round-tripped;
+        follow-up PRs will canonize the remaining cell-intrinsic columns
+        (peak_to_trough_duration, trough_half_width) and re-enable template
+        metrics round-trip.
+        """
         sa = self.read_fn(self.path)
         expected = {
             "random_spikes", "waveforms", "templates", "noise_levels",
             "unit_locations", "correlograms", "isi_histograms",
             "template_similarity", "spike_amplitudes", "amplitude_scalings",
             "spike_locations", "principal_components",
+            "quality_metrics", "spiketrain_metrics",
         }
         self.assertEqual(set(sa.extensions.keys()), expected)
 
@@ -2001,3 +2070,49 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
         sa = self.read_fn(self.path, container_path="ecephys/spike_sorting")
         self.assertIsNotNone(sa)
         self.assertIn("templates", sa.extensions)
+
+    def test_cell_intrinsic_metrics_on_units(self):
+        """Cell-intrinsic metric columns land on nwbfile.units with type tags."""
+        from pynwb import NWBHDF5IO
+        from ndx_spikesorting import FiringRate
+
+        with NWBHDF5IO(self.path, mode="r", load_namespaces=True) as io:
+            nwbfile = io.read()
+            self.assertIsNotNone(nwbfile.units)
+            # FiringRate is the only canonical typed column in v1.
+            typed_columns = {
+                col_name: type(nwbfile.units[col_name]).__name__
+                for col_name in nwbfile.units.colnames
+                if isinstance(nwbfile.units[col_name], FiringRate)
+            }
+            self.assertGreater(len(typed_columns), 0)
+
+    def test_metrics_run_present(self):
+        """Run-dependent metrics land in a MetricsRun instance inside extensions."""
+        from pynwb import NWBHDF5IO
+
+        with NWBHDF5IO(self.path, mode="r", load_namespaces=True) as io:
+            nwbfile = io.read()
+            ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
+            self.assertIn("quality_metrics", ext.metrics_runs)
+
+    def test_metric_values_roundtrip(self):
+        """Reconstructed SI metric extensions hold the same values."""
+        sa = self.read_fn(self.path)
+
+        original_st = self.sorting_analyzer.get_extension("spiketrain_metrics").get_data()
+        restored_st = sa.get_extension("spiketrain_metrics").get_data()
+        np.testing.assert_array_almost_equal(
+            restored_st["firing_rate"].to_numpy(),
+            original_st["firing_rate"].to_numpy(),
+        )
+
+        original_qm = self.sorting_analyzer.get_extension("quality_metrics").get_data()
+        restored_qm = sa.get_extension("quality_metrics").get_data()
+        for col in ("presence_ratio", "isi_violations_ratio"):
+            # NaN-safe comparison.
+            np.testing.assert_allclose(
+                restored_qm[col].to_numpy(),
+                original_qm[col].to_numpy(),
+                equal_nan=True,
+            )

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -1368,14 +1368,14 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
             )
 
 
-def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_valid_intervals: bool = True):
+def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_obs_intervals: bool = True):
     """Create a mock UnitMetrics with plain (untyped) VectorData metric columns.
 
     In v1 no run-dependent metric is canonized as a typed column type (each
     candidate needs multiple attributes to capture cross-pipeline variability;
     see canonical_unit_columns.md in the vault). Columns are stored as plain
     VectorData with their SI metric names preserved. Optionally adds a ragged
-    valid_intervals column with two windows per unit.
+    obs_intervals column with two windows per unit.
     """
     unit_column = DynamicTableRegion(
         name="unit",
@@ -1407,7 +1407,7 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_valid_in
         ),
     ]
 
-    if with_valid_intervals:
+    if with_obs_intervals:
         # Two disjoint windows per unit
         flat = []
         cumulative = []
@@ -1418,18 +1418,18 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_valid_in
             running += 2
             cumulative.append(running)
 
-        valid_intervals_vd = VectorData(
-            name="valid_intervals",
+        obs_intervals_vd = VectorData(
+            name="obs_intervals",
             data=np.array(flat, dtype=np.float64),
             description="Per-unit observation intervals (start, stop) in seconds.",
         )
-        valid_intervals_idx = VectorIndex(
-            name="valid_intervals_index",
+        obs_intervals_idx = VectorIndex(
+            name="obs_intervals_index",
             data=np.array(cumulative, dtype=np.int64),
-            target=valid_intervals_vd,
+            target=obs_intervals_vd,
         )
-        columns.append(valid_intervals_vd)
-        columns.append(valid_intervals_idx)
+        columns.append(obs_intervals_vd)
+        columns.append(obs_intervals_idx)
 
     return UnitMetrics(
         name="quality_metrics",
@@ -1444,29 +1444,29 @@ class TestUnitMetricsConstructor(TestCase):
     def test_constructor_without_intervals(self):
         """UnitMetrics is constructed with typed metric columns."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_valid_intervals=False)
+        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=False)
 
         self.assertEqual(run.name, "quality_metrics")
         self.assertIn("presence_ratio", run.colnames)
         self.assertIn("isi_violations_ratio", run.colnames)
         self.assertIn("unit", run.colnames)
-        self.assertNotIn("valid_intervals", run.colnames)
+        self.assertNotIn("obs_intervals", run.colnames)
         # 3 units => 3 rows
         self.assertEqual(len(run["presence_ratio"].data), 3)
 
     def test_constructor_with_intervals(self):
-        """UnitMetrics carries valid_intervals as a ragged column."""
+        """UnitMetrics carries obs_intervals as a ragged column."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_valid_intervals=True)
+        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=True)
 
-        self.assertIn("valid_intervals", run.colnames)
+        self.assertIn("obs_intervals", run.colnames)
         # 3 units * 2 windows => 6 intervals in the flat data
-        self.assertEqual(run["valid_intervals"].target.data.shape, (6, 2))
+        self.assertEqual(run["obs_intervals"].target.data.shape, (6, 2))
 
     def test_plain_column_values(self):
         """UnitMetrics stores run-dependent metrics as plain VectorData (v1)."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_valid_intervals=False)
+        run = create_mock_unit_metrics(nwbfile, with_obs_intervals=False)
 
         # No typed-column attributes in v1; columns are plain VectorData.
         self.assertEqual(len(run["presence_ratio"].data), 3)
@@ -1492,7 +1492,7 @@ class TestUnitMetricsRoundtrip(TestCase):
         )
         units_region = create_units_region(self.nwbfile)
 
-        run = create_mock_unit_metrics(self.nwbfile, with_valid_intervals=True)
+        run = create_mock_unit_metrics(self.nwbfile, with_obs_intervals=True)
 
         extensions = SpikeSortingExtensions(name="extensions")
         extensions.add_unit_metrics(run)
@@ -1526,10 +1526,10 @@ class TestUnitMetricsRoundtrip(TestCase):
             np.testing.assert_array_almost_equal(
                 read_run["isi_violations_ratio"][:], run["isi_violations_ratio"].data
             )
-            # valid_intervals round-trip: VectorIndex view gives cumulative, target gives flat data
+            # obs_intervals round-trip: VectorIndex view gives cumulative, target gives flat data
             np.testing.assert_array_equal(
-                read_run["valid_intervals"].target.data[:],
-                run["valid_intervals"].target.data,
+                read_run["obs_intervals"].target.data[:],
+                run["obs_intervals"].target.data,
             )
 
 

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -2068,12 +2068,12 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
     def test_loads_all_extensions(self):
         """Extensions restored from the NWB file.
 
-        v1 canonizes one typed column (FiringRate) on Units and writes
-        quality_metrics to UnitMetrics as plain VectorData. template_metrics
-        columns are not yet typed and are not currently round-tripped;
-        follow-up PRs will canonize the remaining cell-intrinsic columns
-        (peak_to_trough_duration, trough_half_width) and re-enable template
-        metrics round-trip.
+        Quality, template, and spiketrain metric columns all live on a
+        single UnitMetrics table on disk; the reader uses
+        ``COLUMN_TO_EXTENSION`` to split them back into the right SI
+        extensions on read. ``FiringRate`` is the only canonized typed
+        column on Units in v1 (additional canonical columns are in
+        follow-up PRs); it routes to ``spiketrain_metrics``.
         """
         sa = self.read_fn(self.path)
         expected = {
@@ -2081,7 +2081,7 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
             "unit_locations", "correlograms", "isi_histograms",
             "template_similarity", "spike_amplitudes", "amplitude_scalings",
             "spike_locations", "principal_components",
-            "quality_metrics", "spiketrain_metrics",
+            "quality_metrics", "template_metrics", "spiketrain_metrics",
         }
         self.assertEqual(set(sa.extensions.keys()), expected)
 
@@ -2210,3 +2210,68 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
                 original_qm[col].to_numpy(),
                 equal_nan=True,
             )
+
+    def test_template_metrics_roundtrip(self):
+        """template_metrics columns split out of UnitMetrics into the right SI extension."""
+        sa = self.read_fn(self.path)
+
+        original_tm = self.sorting_analyzer.get_extension("template_metrics").get_data()
+        restored_tm = sa.get_extension("template_metrics").get_data()
+        # Sanity check: the SI extension is restored, not merged into quality_metrics.
+        self.assertIsNotNone(restored_tm)
+        # Every template-metric column from the original is present and equal.
+        for col in original_tm.columns:
+            self.assertIn(col, restored_tm.columns, f"template_metrics missing {col!r}")
+            np.testing.assert_allclose(
+                restored_tm[col].to_numpy(),
+                original_tm[col].to_numpy(),
+                equal_nan=True,
+            )
+
+    def test_quality_and_template_metrics_separated_on_read(self):
+        """quality_metrics and template_metrics extensions hold disjoint columns post-read.
+
+        Pre-fix, every column on UnitMetrics was funneled into quality_metrics,
+        which made template_metrics empty (or absent) and put template columns
+        like ``peak_to_trough_duration`` under quality_metrics.
+        """
+        sa = self.read_fn(self.path)
+
+        qm_cols = set(sa.get_extension("quality_metrics").get_data().columns)
+        tm_cols = set(sa.get_extension("template_metrics").get_data().columns)
+
+        # template_metrics columns should NOT be in quality_metrics.
+        leaked = {"peak_to_trough_duration", "trough_half_width", "peak_half_width"} & qm_cols
+        self.assertEqual(leaked, set(), f"template columns leaked into quality_metrics: {leaked}")
+
+        # quality_metrics columns should NOT be in template_metrics.
+        leaked = {"presence_ratio", "isi_violations_ratio"} & tm_cols
+        self.assertEqual(leaked, set(), f"quality columns leaked into template_metrics: {leaked}")
+
+    def test_column_to_extension_covers_all_computed_columns(self):
+        """COLUMN_TO_EXTENSION covers every column produced by the SI extensions
+        we compute in the fixture.
+
+        Acts as a guard: if SI adds a new column in a release, the test fails
+        with a clear message naming the uncovered column. Update
+        ``COLUMN_TO_EXTENSION`` in ``utils.py`` to silence.
+        """
+        from ndx_spikesorting.utils import COLUMN_TO_EXTENSION
+
+        uncovered = []
+        for ext_name in ("template_metrics", "quality_metrics", "spiketrain_metrics"):
+            ext = self.sorting_analyzer.get_extension(ext_name)
+            if ext is None:
+                continue
+            df_cols = ext.get_data().columns
+            for col in df_cols:
+                if col not in COLUMN_TO_EXTENSION:
+                    uncovered.append((ext_name, col))
+
+        self.assertEqual(
+            uncovered,
+            [],
+            "Columns produced by SpikeInterface (SI) but missing from "
+            f"COLUMN_TO_EXTENSION: {uncovered}. Add them to the dict in "
+            "src/pynwb/ndx_spikesorting/utils.py.",
+        )

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -2056,8 +2056,8 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
         """Extensions restored from the NWB file.
 
         Quality, template, and spiketrain metric columns all live on a
-        single UnitsMetrics table on disk; the reader uses
-        ``COLUMN_TO_EXTENSION`` to split them back into the right SI
+        single UnitsMetrics table on disk; the reader uses metric names
+        to split them back into the right SI
         extensions on read. ``FiringRate`` is the only canonized typed
         column on Units in v1 (additional canonical columns are in
         follow-up PRs); it routes to ``spiketrain_metrics``.
@@ -2175,7 +2175,7 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
         with NWBHDF5IO(self.path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
             ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
-            self.assertIn("quality_metrics", ext.units_metrics)
+            self.assertIn("unit_metrics", ext.units_metrics)
 
     def test_metric_values_roundtrip(self):
         """Reconstructed SI metric extensions hold the same values."""
@@ -2235,34 +2235,6 @@ class TestReadSortingAnalyzerFromNwb(TestCase):
         leaked = {"presence_ratio", "isi_violations_ratio"} & tm_cols
         self.assertEqual(leaked, set(), f"quality columns leaked into template_metrics: {leaked}")
 
-    def test_column_to_extension_covers_all_computed_columns(self):
-        """COLUMN_TO_EXTENSION covers every column produced by the SI extensions
-        we compute in the fixture.
-
-        Acts as a guard: if SI adds a new column in a release, the test fails
-        with a clear message naming the uncovered column. Update
-        ``COLUMN_TO_EXTENSION`` in ``utils.py`` to silence.
-        """
-        from ndx_spikesorting.utils import COLUMN_TO_EXTENSION
-
-        uncovered = []
-        for ext_name in ("template_metrics", "quality_metrics", "spiketrain_metrics"):
-            ext = self.sorting_analyzer.get_extension(ext_name)
-            if ext is None:
-                continue
-            df_cols = ext.get_data().columns
-            for col in df_cols:
-                if col not in COLUMN_TO_EXTENSION:
-                    uncovered.append((ext_name, col))
-
-        self.assertEqual(
-            uncovered,
-            [],
-            "Columns produced by SpikeInterface (SI) but missing from "
-            f"COLUMN_TO_EXTENSION: {uncovered}. Add them to the dict in "
-            "src/pynwb/ndx_spikesorting/utils.py.",
-        )
-
 
 class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
     """Round-trip the time_support column-attribute link through a SortingAnalyzer.
@@ -2305,7 +2277,14 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
             periods.append((0, int(2.0 * fs), int(4.5 * fs), u))
         self.periods_arr = np.array(periods, dtype=unit_period_dtype)
         self.sorting_analyzer.compute(
-            {"quality_metrics": {"periods": self.periods_arr, "metric_names": ["firing_rate", "presence_ratio"]}}
+            {
+                "quality_metrics": 
+                    {
+                        "periods": self.periods_arr,
+                        "metric_names": ["firing_rate", "presence_ratio"],
+                        "metric_params": {"presence_ratio": {"bin_duration_s": 1.0}}
+                    }
+            }
         )
 
         self.path = "test_units_metrics_time_support_link.nwb"
@@ -2337,7 +2316,7 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
 
         # In-memory: metric columns carry the link and the standalone table exists.
         ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
-        um = ext.units_metrics["quality_metrics"]
+        um = ext.units_metrics["unit_metrics"]
         self.assertIsNotNone(um["presence_ratio"].time_support)
         self.assertIsNotNone(ext.valid_unit_periods)
         # No legacy inline column.
@@ -2416,15 +2395,15 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
 
         # Re-compute quality_metrics without periods.
         self.sorting_analyzer.compute(
-            {"quality_metrics": {"metric_names": ["firing_rate"], "delete_existing_metrics": True}}
+            {"quality_metrics": {"metric_names": ["presence_ratio"], "delete_existing_metrics": True}}
         )
 
         nwbfile = self._build_nwbfile()
         add_sorting_analyzer_to_nwbfile(self.sorting_analyzer, nwbfile)
 
         ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
-        um = ext.units_metrics["quality_metrics"]
-        self.assertIsNone(getattr(um["firing_rate"], "time_support", None))
+        um = ext.units_metrics["unit_metrics"]
+        self.assertIsNone(getattr(um["presence_ratio"], "time_support", None))
         self.assertEqual(len(ext.valid_unit_periods), 0)
 
     def test_qm_periods_without_si_extension_writes_plain_time_intervals(self):
@@ -2435,7 +2414,7 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
         self.sorting_analyzer.compute(
             {"quality_metrics": {
                 "periods": self.periods_arr,
-                "metric_names": ["firing_rate", "presence_ratio"],
+                "metric_names": ["presence_ratio"],
                 "delete_existing_metrics": True,
             }}
         )
@@ -2446,10 +2425,10 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
         ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
         self.assertEqual(len(ext.valid_unit_periods), 0)
         self.assertEqual(len(ext.time_intervals), 1)
-        self.assertIn("quality_metrics_time_support", ext.time_intervals)
+        self.assertIn("unit_metrics_time_support", ext.time_intervals)
 
-        um = ext.units_metrics["quality_metrics"]
-        ts = um["firing_rate"].time_support
+        um = ext.units_metrics["unit_metrics"]
+        ts = um["presence_ratio"].time_support
         self.assertIsNotNone(ts)
         # Should NOT be a ValidUnitPeriods (no SI extension); should be a plain TimeIntervals.
         from ndx_spikesorting import ValidUnitPeriods
@@ -2470,7 +2449,7 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
         self.sorting_analyzer.compute(
             {"quality_metrics": {
                 "periods": self.periods_arr,
-                "metric_names": ["firing_rate", "snr"],
+                "metric_names": ["presence_ratio", "snr"],
                 "delete_existing_metrics": True,
             }}
         )
@@ -2479,10 +2458,10 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
         add_sorting_analyzer_to_nwbfile(self.sorting_analyzer, nwbfile)
 
         ext = nwbfile.processing["ecephys"]["spike_sorting"].spike_sorting_extensions
-        um = ext.units_metrics["quality_metrics"]
+        um = ext.units_metrics["unit_metrics"]
 
-        # firing_rate should have a time_support link (supports_periods=True)
-        self.assertIsNotNone(um["firing_rate"].time_support)
+        # presence_ratio should have a time_support link (supports_periods=True)
+        self.assertIsNotNone(um["presence_ratio"].time_support)
         # snr should not (supports_periods=False — value doesn't depend on periods)
         self.assertIsNone(um["snr"].time_support)
 
@@ -2506,7 +2485,7 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
         )
         self.sorting_analyzer.compute({"quality_metrics": {
             "periods": qm_periods,
-            "metric_names": ["firing_rate"],
+            "metric_names": ["presence_ratio"],
             "delete_existing_metrics": True,
         }})
 
@@ -2519,6 +2498,6 @@ class TestUnitsMetricsTimeSupportLinkRoundtrip(TestCase):
         self.assertEqual(len(ext.time_intervals), 1)
 
         # Metric column links to the qm-derived TimeIntervals, not the ValidUnitPeriods
-        um = ext.units_metrics["quality_metrics"]
+        um = ext.units_metrics["unit_metrics"]
         from ndx_spikesorting import ValidUnitPeriods
-        self.assertNotIsInstance(um["firing_rate"].time_support, ValidUnitPeriods)
+        self.assertNotIsInstance(um["presence_ratio"].time_support, ValidUnitPeriods)

--- a/src/pynwb/tests/test_spikesorting.py
+++ b/src/pynwb/tests/test_spikesorting.py
@@ -1369,10 +1369,10 @@ class TestAmplitudeScalingsRoundtrip(TestCase):
             )
 
 
-def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_computation_intervals: bool = True):
+def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_time_support: bool = True):
     """Create a mock UnitMetrics with plain VectorData metric columns.
 
-    Optionally adds a ragged computation_intervals column with two windows per unit.
+    Optionally adds a ragged time_support column with two windows per unit.
     """
     unit_column = DynamicTableRegion(
         name="unit",
@@ -1404,7 +1404,7 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_computat
         ),
     ]
 
-    if with_computation_intervals:
+    if with_time_support:
         flat = []
         cumulative = []
         running = 0
@@ -1414,18 +1414,18 @@ def create_mock_unit_metrics(nwbfile: NWBFile, num_units: int = 3, with_computat
             running += 2
             cumulative.append(running)
 
-        computation_intervals_vd = VectorData(
-            name="computation_intervals",
+        time_support_vd = VectorData(
+            name="time_support",
             data=np.array(flat, dtype=np.float64),
             description="Per-unit time intervals (start, stop) in seconds over which metrics were computed.",
         )
-        computation_intervals_idx = VectorIndex(
-            name="computation_intervals_index",
+        time_support_idx = VectorIndex(
+            name="time_support_index",
             data=np.array(cumulative, dtype=np.int64),
-            target=computation_intervals_vd,
+            target=time_support_vd,
         )
-        columns.append(computation_intervals_vd)
-        columns.append(computation_intervals_idx)
+        columns.append(time_support_vd)
+        columns.append(time_support_idx)
 
     return UnitMetrics(
         name="quality_metrics",
@@ -1473,25 +1473,25 @@ class TestUnitMetricsConstructor(TestCase):
     def test_constructor_without_intervals(self):
         """UnitMetrics is constructed with the expected columns."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_computation_intervals=False)
+        run = create_mock_unit_metrics(nwbfile, with_time_support=False)
 
         self.assertEqual(run.name, "quality_metrics")
         self.assertIn("presence_ratio", run.colnames)
         self.assertIn("isi_violations_ratio", run.colnames)
         self.assertIn("unit", run.colnames)
-        self.assertNotIn("computation_intervals", run.colnames)
+        self.assertNotIn("time_support", run.colnames)
         self.assertEqual(len(run["presence_ratio"].data), 3)
         self.assertEqual(len(run["isi_violations_ratio"].data), 3)
         self.assertEqual(len(run["amplitude_cutoff"].data), 3)
 
     def test_constructor_with_intervals(self):
-        """UnitMetrics carries computation_intervals as a ragged column."""
+        """UnitMetrics carries time_support as a ragged column."""
         nwbfile = set_up_nwbfile()
-        run = create_mock_unit_metrics(nwbfile, with_computation_intervals=True)
+        run = create_mock_unit_metrics(nwbfile, with_time_support=True)
 
-        self.assertIn("computation_intervals", run.colnames)
+        self.assertIn("time_support", run.colnames)
         # 3 units * 2 windows => 6 intervals in the flat data
-        self.assertEqual(run["computation_intervals"].target.data.shape, (6, 2))
+        self.assertEqual(run["time_support"].target.data.shape, (6, 2))
 
 
 class TestUnitMetricsRoundtrip(TestCase):
@@ -1512,7 +1512,7 @@ class TestUnitMetricsRoundtrip(TestCase):
         )
         units_region = create_units_region(self.nwbfile)
 
-        run = create_mock_unit_metrics(self.nwbfile, with_computation_intervals=True)
+        run = create_mock_unit_metrics(self.nwbfile, with_time_support=True)
 
         extensions = SpikeSortingExtensions(name="extensions")
         extensions.add_unit_metrics(run)
@@ -1547,8 +1547,8 @@ class TestUnitMetricsRoundtrip(TestCase):
                 read_run["isi_violations_ratio"][:], run["isi_violations_ratio"].data
             )
             np.testing.assert_array_equal(
-                read_run["computation_intervals"].target.data[:],
-                run["computation_intervals"].target.data,
+                read_run["time_support"].target.data[:],
+                run["time_support"].target.data,
             )
 
 

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -570,12 +570,9 @@ def main():
         neurodata_type_inc="VectorData",
         dtype="float",
         doc=(
-            "Mean firing rate of the unit. When obs_intervals is populated on the "
-            "units table, the rate is computed over the union of the unit's valid "
-            "windows (n_spikes_in_valid_windows / sum(valid_durations)). When "
-            "obs_intervals is absent or empty, the rate is computed over the whole "
-            "recording duration. Cell-intrinsic property; written as a column on "
-            "nwbfile.units."
+            "Mean firing rate of the unit, computed as the number of spikes "
+            "divided by the recording duration. Cell-intrinsic property; "
+            "written as a column on nwbfile.units."
         ),
         attributes=[
             NWBAttributeSpec(
@@ -587,19 +584,6 @@ def main():
         ],
     )
 
-    # Other canonical column candidates (PeakToTroughSeconds, TroughHalfWidthSeconds,
-    # AmplitudeMedian on the cell-intrinsic side; Snr, PresenceRatio,
-    # IsiViolationsRatio, AmplitudeCutoff on the run-dependent side) were considered
-    # for v1 and deferred to follow-up PRs after cross-pipeline variability research.
-    # They still round-trip as plain VectorData columns on the appropriate table
-    # (nwbfile.units or UnitMetrics instances), just without typed-column tags.
-    # Background: see `canonical_unit_columns.md` in the project vault.
-
-    # ------------------------------------------------------------------
-    # UnitMetrics: multi-instance container for per-unit metrics from one
-    # analysis run. Required `unit` DynamicTableRegion makes the row-to-unit
-    # mapping explicit. Multiple instances coexist under SpikeSortingExtensions
-    # so multiple runs (with different parameters) can be stored in one file.
     unit_metrics = NWBGroupSpec(
         neurodata_type_def="UnitMetrics",
         neurodata_type_inc="DynamicTable",
@@ -622,10 +606,6 @@ def main():
         ],
     )
 
-    # ValidUnitPeriods: valid time periods for each unit using TimeIntervals.
-    # Carried over from PR #17. A follow-up PR may migrate per-unit valid
-    # windows to NWB-core Units.obs_intervals and deprecate this type; that
-    # change is scoped separately to keep the present PR's diff small.
     valid_unit_periods = NWBGroupSpec(
         neurodata_type_def="ValidUnitPeriods",
         neurodata_type_inc="TimeIntervals",

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -604,26 +604,26 @@ def main():
                 ),
             ),
             NWBDatasetSpec(
-                name="computation_intervals",
+                name="time_support",
                 neurodata_type_inc="VectorData",
                 dtype="float",
                 dims=["num_intervals", "start_end"],
                 shape=[None, 2],
                 doc=(
                     "Per-unit time intervals (start, stop) in seconds over which this "
-                    "row's metric values were computed. Captures the `periods` argument "
-                    "passed to the SpikeInterface metric extension at compute time. "
-                    "Ragged by row via computation_intervals_index. Distinct from "
-                    "`Units.obs_intervals` (NWB-core), which constrains the validity of "
-                    "`spike_times` on the Units table; this column records the analysis-time "
-                    "windows used as input to this row's computation."
+                    "row's metric values were computed. Each row's metric values reflect "
+                    "only events that fell within these per-unit windows. Ragged by row "
+                    "via time_support_index. Distinct from `Units.obs_intervals` (NWB-core), "
+                    "which constrains the validity of `spike_times` on the Units table; "
+                    "this column records the analysis-time windows used as input to this "
+                    "row's computation."
                 ),
                 quantity="?",
             ),
             NWBDatasetSpec(
-                name="computation_intervals_index",
+                name="time_support_index",
                 neurodata_type_inc="VectorIndex",
-                doc="Index column for the ragged computation_intervals column.",
+                doc="Index column for the ragged time_support column.",
                 quantity="?",
             ),
         ],

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -585,23 +585,27 @@ def main():
         ],
     )
 
-    metric_vector_data = NWBDatasetSpec(
-        neurodata_type_def="MetricVectorData",
+    unit_vector_data = NWBDatasetSpec(
+        neurodata_type_def="UnitVectorData",
         neurodata_type_inc="VectorData",
         doc=(
-            "A VectorData column carrying a run-dependent per-unit metric. May "
-            "reference the TimeIntervals (typically ValidUnitPeriods) over which "
-            "its values were computed, via the optional `time_support` attribute."
+            "A VectorData column carrying per-unit values. May reference the "
+            "TimeIntervals over which the values were computed, via the optional "
+            "`time_support` attribute. Used as the column type for run-dependent "
+            "metric values on UnitsMetrics; also suitable for cell-intrinsic "
+            "typed columns on the Units table."
         ),
         attributes=[
             NWBAttributeSpec(
                 name="time_support",
                 doc=(
-                    "Object reference to the TimeIntervals (typically "
-                    "ValidUnitPeriods) over which this column's metric values "
-                    "were computed. Absent when no time restriction was applied."
+                    "Object reference to the TimeIntervals (plain or a "
+                    "ValidUnitPeriods subclass) over which this column's values "
+                    "were computed. Absent when no time restriction was applied "
+                    "(e.g., for metrics whose computation does not respect "
+                    "per-unit periods)."
                 ),
-                dtype=NWBRefSpec(target_type="ValidUnitPeriods", reftype="object"),
+                dtype=NWBRefSpec(target_type="TimeIntervals", reftype="object"),
                 required=False,
             ),
         ],
@@ -613,7 +617,7 @@ def main():
         default_name="units_metrics",
         doc=(
             "Per-unit metric values from one analysis run. Each row is one unit; "
-            "columns are metric values, typed as MetricVectorData so they can carry "
+            "columns are metric values, typed as UnitVectorData so they can carry "
             "an optional reference to the TimeIntervals over which they were "
             "computed. The required `unit` DynamicTableRegion references the "
             "corresponding row in nwbfile.units. Multiple instances coexist under "
@@ -739,8 +743,23 @@ def main():
             ),
             NWBGroupSpec(
                 neurodata_type_inc="ValidUnitPeriods",
-                quantity="?",
-                doc="Valid unit periods extension data.",
+                quantity="*",
+                doc=(
+                    "Valid time periods per unit from spike sorting quality "
+                    "estimation. Multiple instances may coexist when different "
+                    "analysis parameter sets produce different validity tables."
+                ),
+            ),
+            NWBGroupSpec(
+                neurodata_type_inc="TimeIntervals",
+                quantity="*",
+                doc=(
+                    "Plain NWB-core TimeIntervals tables, used for metric "
+                    "time-support windows when those windows did not come from a "
+                    "validity computation (e.g., user-defined periods passed "
+                    "directly to quality_metrics). Each row has start_time, "
+                    "stop_time, and a `unit` DynamicTableRegion column."
+                ),
             ),
         ],
     )
@@ -827,7 +846,7 @@ def main():
         pca_projections_concatenated,
         firing_rate,
         valid_unit_periods,
-        metric_vector_data,
+        unit_vector_data,
         units_metrics,
         spike_sorting_extensions,
         spike_sorting_container,

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -604,22 +604,26 @@ def main():
                 ),
             ),
             NWBDatasetSpec(
-                name="obs_intervals",
+                name="computation_intervals",
                 neurodata_type_inc="VectorData",
                 dtype="float",
                 dims=["num_intervals", "start_end"],
                 shape=[None, 2],
                 doc=(
-                    "Per-unit observation intervals (start, stop) in seconds over which "
-                    "this row's metric values were computed. Ragged by row via "
-                    "obs_intervals_index."
+                    "Per-unit time intervals (start, stop) in seconds over which this "
+                    "row's metric values were computed. Captures the `periods` argument "
+                    "passed to the SpikeInterface metric extension at compute time. "
+                    "Ragged by row via computation_intervals_index. Distinct from "
+                    "`Units.obs_intervals` (NWB-core), which constrains the validity of "
+                    "`spike_times` on the Units table; this column records the analysis-time "
+                    "windows used as input to this row's computation."
                 ),
                 quantity="?",
             ),
             NWBDatasetSpec(
-                name="obs_intervals_index",
+                name="computation_intervals_index",
                 neurodata_type_inc="VectorIndex",
-                doc="Index column for the ragged obs_intervals column.",
+                doc="Index column for the ragged computation_intervals column.",
                 quantity="?",
             ),
         ],

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -603,6 +603,25 @@ def main():
                     "UnitMetrics describes."
                 ),
             ),
+            NWBDatasetSpec(
+                name="obs_intervals",
+                neurodata_type_inc="VectorData",
+                dtype="float",
+                dims=["num_intervals", "start_end"],
+                shape=[None, 2],
+                doc=(
+                    "Per-unit observation intervals (start, stop) in seconds over which "
+                    "this row's metric values were computed. Ragged by row via "
+                    "obs_intervals_index."
+                ),
+                quantity="?",
+            ),
+            NWBDatasetSpec(
+                name="obs_intervals_index",
+                neurodata_type_inc="VectorIndex",
+                doc="Index column for the ragged obs_intervals column.",
+                quantity="?",
+            ),
         ],
     )
 

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -8,6 +8,7 @@ from pynwb.spec import (
     NWBAttributeSpec,
     NWBDatasetSpec,
     NWBLinkSpec,
+    NWBRefSpec,
 )
 
 
@@ -584,15 +585,39 @@ def main():
         ],
     )
 
+    metric_vector_data = NWBDatasetSpec(
+        neurodata_type_def="MetricVectorData",
+        neurodata_type_inc="VectorData",
+        doc=(
+            "A VectorData column carrying a run-dependent per-unit metric. May "
+            "reference the TimeIntervals (typically ValidUnitPeriods) over which "
+            "its values were computed, via the optional `time_support` attribute."
+        ),
+        attributes=[
+            NWBAttributeSpec(
+                name="time_support",
+                doc=(
+                    "Object reference to the TimeIntervals (typically "
+                    "ValidUnitPeriods) over which this column's metric values "
+                    "were computed. Absent when no time restriction was applied."
+                ),
+                dtype=NWBRefSpec(target_type="ValidUnitPeriods", reftype="object"),
+                required=False,
+            ),
+        ],
+    )
+
     unit_metrics = NWBGroupSpec(
         neurodata_type_def="UnitMetrics",
         neurodata_type_inc="DynamicTable",
         default_name="unit_metrics",
         doc=(
             "Per-unit metric values from one analysis run. Each row is one unit; "
-            "columns are metric values. The required `unit` DynamicTableRegion "
-            "references the corresponding row in nwbfile.units. Multiple instances "
-            "coexist under SpikeSortingExtensions for different analysis runs."
+            "columns are metric values, typed as MetricVectorData so they can carry "
+            "an optional reference to the TimeIntervals over which they were "
+            "computed. The required `unit` DynamicTableRegion references the "
+            "corresponding row in nwbfile.units. Multiple instances coexist under "
+            "SpikeSortingExtensions for different analysis runs."
         ),
         datasets=[
             NWBDatasetSpec(
@@ -602,29 +627,6 @@ def main():
                     "Reference to the row in nwbfile.units that each row of this "
                     "UnitMetrics describes."
                 ),
-            ),
-            NWBDatasetSpec(
-                name="time_support",
-                neurodata_type_inc="VectorData",
-                dtype="float",
-                dims=["num_intervals", "start_end"],
-                shape=[None, 2],
-                doc=(
-                    "Per-unit time intervals (start, stop) in seconds over which this "
-                    "row's metric values were computed. Each row's metric values reflect "
-                    "only events that fell within these per-unit windows. Ragged by row "
-                    "via time_support_index. Distinct from `Units.obs_intervals` (NWB-core), "
-                    "which constrains the validity of `spike_times` on the Units table; "
-                    "this column records the analysis-time windows used as input to this "
-                    "row's computation."
-                ),
-                quantity="?",
-            ),
-            NWBDatasetSpec(
-                name="time_support_index",
-                neurodata_type_inc="VectorIndex",
-                doc="Index column for the ragged time_support column.",
-                quantity="?",
             ),
         ],
     )
@@ -824,8 +826,9 @@ def main():
         pca_projections_by_channel,
         pca_projections_concatenated,
         firing_rate,
-        unit_metrics,
         valid_unit_periods,
+        metric_vector_data,
+        unit_metrics,
         spike_sorting_extensions,
         spike_sorting_container,
     ]

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -596,20 +596,19 @@ def main():
     # Background: see `canonical_unit_columns.md` in the project vault.
 
     # ------------------------------------------------------------------
-    # UnitMetrics: multi-instance container for run-dependent metrics
-    # ------------------------------------------------------------------
+    # UnitMetrics: multi-instance container for per-unit metrics from one
+    # analysis run. Required `unit` DynamicTableRegion makes the row-to-unit
+    # mapping explicit. Multiple instances coexist under SpikeSortingExtensions
+    # so multiple runs (with different parameters) can be stored in one file.
     unit_metrics = NWBGroupSpec(
         neurodata_type_def="UnitMetrics",
         neurodata_type_inc="DynamicTable",
         default_name="unit_metrics",
         doc=(
-            "One analysis run's worth of per-unit run-dependent metrics. Each row "
-            "is one unit; columns are run-dependent metric values stored as "
-            "plain VectorData (no canonical types committed in v1). "
-            "Multiple UnitMetrics instances coexist under SpikeSortingExtensions for "
-            "multiple curation runs (default run, valid-window-restricted run, "
-            "per-period drift QC runs). The instance name carries the run identity "
-            "(e.g., 'quality_metrics_default', 'quality_metrics_valid_windows')."
+            "Per-unit metric values from one analysis run. Each row is one unit; "
+            "columns are metric values. The required `unit` DynamicTableRegion "
+            "references the corresponding row in nwbfile.units. Multiple instances "
+            "coexist under SpikeSortingExtensions for different analysis runs."
         ),
         datasets=[
             NWBDatasetSpec(
@@ -617,28 +616,35 @@ def main():
                 neurodata_type_inc="DynamicTableRegion",
                 doc=(
                     "Reference to the row in nwbfile.units that each row of this "
-                    "UnitMetrics describes. Makes row-to-unit alignment explicit."
+                    "UnitMetrics describes."
                 ),
             ),
+        ],
+    )
+
+    # ValidUnitPeriods: valid time periods for each unit using TimeIntervals.
+    # Carried over from PR #17. A follow-up PR may migrate per-unit valid
+    # windows to NWB-core Units.obs_intervals and deprecate this type; that
+    # change is scoped separately to keep the present PR's diff small.
+    valid_unit_periods = NWBGroupSpec(
+        neurodata_type_def="ValidUnitPeriods",
+        neurodata_type_inc="TimeIntervals",
+        default_name="valid_unit_periods",
+        doc=(
+            "Valid time periods for each unit, typically computed from false positive/negative "
+            "rate estimation or user-defined. Each row represents one valid period "
+            "for one unit, with start and stop times inherited from TimeIntervals. "
+            "If a unit has multiple disjoint valid periods, each period is stored as a "
+            "separate row referencing the same unit."
+        ),
+        datasets=[
             NWBDatasetSpec(
-                name="valid_intervals",
-                neurodata_type_inc="VectorData",
-                dtype="float",
-                dims=["num_intervals", "start|end"],
-                shape=[None, 2],
-                quantity="?",
+                name="unit",
+                neurodata_type_inc="DynamicTableRegion",
                 doc=(
-                    "Per-unit observation intervals (start, stop) pairs in seconds, "
-                    "describing the time windows over which metrics in this run were "
-                    "computed. If absent, the metrics were computed over the whole "
-                    "recording."
+                    "Reference to the units table for each row, identifying which unit "
+                    "each valid period belongs to."
                 ),
-            ),
-            NWBDatasetSpec(
-                name="valid_intervals_index",
-                neurodata_type_inc="VectorIndex",
-                quantity="?",
-                doc="Index into valid_intervals for each row, grouping intervals by row.",
             ),
         ],
     )
@@ -722,9 +728,14 @@ def main():
                 neurodata_type_inc="UnitMetrics",
                 quantity="*",
                 doc=(
-                    "Run-dependent per-unit metrics, one instance per analysis run. "
-                    "Multiple instances coexist for different curation runs."
+                    "Per-unit metrics from one analysis run. Multiple instances "
+                    "coexist for different runs (different parameter sets)."
                 ),
+            ),
+            NWBGroupSpec(
+                neurodata_type_inc="ValidUnitPeriods",
+                quantity="?",
+                doc="Valid unit periods extension data.",
             ),
         ],
     )
@@ -809,15 +820,9 @@ def main():
         amplitude_scalings,
         pca_projections_by_channel,
         pca_projections_concatenated,
-        # Canonical typed VectorData columns (cell-intrinsic, live on nwbfile.units)
         firing_rate,
-        # No canonical typed VectorData columns are committed for the
-        # run-dependent side in v1. Run-dependent metrics still flow into
-        # UnitMetrics instances as plain VectorData columns; the field has
-        # not converged on canonical conventions yet (see vault note
-        # canonical_unit_columns.md). Add typed columns here in v2.
-        # Multi-instance container for run-dependent metrics
         unit_metrics,
+        valid_unit_periods,
         spike_sorting_extensions,
         spike_sorting_container,
     ]

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -558,7 +558,7 @@ def main():
     # Canonical typed VectorData column classes
     # ------------------------------------------------------------------
     # These are stand-alone VectorData subtypes that the writer adds to either
-    # nwbfile.units (cell-intrinsic properties) or UnitMetrics instances
+    # nwbfile.units (cell-intrinsic properties) or UnitsMetrics instances
     # (run-dependent properties). The split is by what the value is, not by what
     # it is used for: cell-intrinsic values estimate biological properties and
     # are stable across reasonable analyses; run-dependent values describe the
@@ -607,10 +607,10 @@ def main():
         ],
     )
 
-    unit_metrics = NWBGroupSpec(
-        neurodata_type_def="UnitMetrics",
+    units_metrics = NWBGroupSpec(
+        neurodata_type_def="UnitsMetrics",
         neurodata_type_inc="DynamicTable",
-        default_name="unit_metrics",
+        default_name="units_metrics",
         doc=(
             "Per-unit metric values from one analysis run. Each row is one unit; "
             "columns are metric values, typed as MetricVectorData so they can carry "
@@ -625,7 +625,7 @@ def main():
                 neurodata_type_inc="DynamicTableRegion",
                 doc=(
                     "Reference to the row in nwbfile.units that each row of this "
-                    "UnitMetrics describes."
+                    "UnitsMetrics describes."
                 ),
             ),
         ],
@@ -730,7 +730,7 @@ def main():
                 doc="Concatenated-channels PCA projections of spikes (single-ragged).",
             ),
             NWBGroupSpec(
-                neurodata_type_inc="UnitMetrics",
+                neurodata_type_inc="UnitsMetrics",
                 quantity="*",
                 doc=(
                     "Per-unit metrics from one analysis run. Multiple instances "
@@ -828,7 +828,7 @@ def main():
         firing_rate,
         valid_unit_periods,
         metric_vector_data,
-        unit_metrics,
+        units_metrics,
         spike_sorting_extensions,
         spike_sorting_container,
     ]

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -26,6 +26,10 @@ def main():
         ],
     )
     ns_builder.include_namespace("core")
+    ns_builder.include_type("DynamicTable", namespace="hdmf-common")
+    ns_builder.include_type("VectorData", namespace="hdmf-common")
+    ns_builder.include_type("VectorIndex", namespace="hdmf-common")
+    ns_builder.include_type("DynamicTableRegion", namespace="hdmf-common")
 
     # RandomSpikes: stores random spike indices per unit for waveform extraction
     random_spikes = NWBGroupSpec(
@@ -549,26 +553,123 @@ def main():
         ],
     )
 
-    # ValidUnitPeriods: valid time periods for each unit using TimeIntervals
-    valid_unit_periods = NWBGroupSpec(
-        neurodata_type_def="ValidUnitPeriods",
-        neurodata_type_inc="TimeIntervals",
-        default_name="valid_unit_periods",
+    # ------------------------------------------------------------------
+    # Canonical typed VectorData column classes
+    # ------------------------------------------------------------------
+    # These are stand-alone VectorData subtypes that the writer adds to either
+    # nwbfile.units (cell-intrinsic properties) or MetricsRun instances
+    # (run-dependent properties). The split is by what the value is, not by what
+    # it is used for: cell-intrinsic values estimate biological properties and
+    # are stable across reasonable analyses; run-dependent values describe the
+    # analysis itself and vary with parameter choices.
+
+    # Cell-intrinsic: live on nwbfile.units
+
+    firing_rate = NWBDatasetSpec(
+        neurodata_type_def="FiringRate",
+        neurodata_type_inc="VectorData",
+        dtype="float",
         doc=(
-            "Valid time periods for each unit, typically computed from false positive/negative "
-            "rate estimation or user-defined. Each row represents one valid period "
-            "for one unit, with start and stop times inherited from TimeIntervals. "
-            "If a unit has multiple disjoint valid periods, each period is stored as a "
-            "separate row referencing the same unit."
+            "Mean firing rate of the unit. When obs_intervals is populated on the "
+            "units table, the rate is computed over the union of the unit's valid "
+            "windows (n_spikes_in_valid_windows / sum(valid_durations)). When "
+            "obs_intervals is absent or empty, the rate is computed over the whole "
+            "recording duration. Cell-intrinsic property; written as a column on "
+            "nwbfile.units."
+        ),
+        attributes=[
+            NWBAttributeSpec(
+                name="unit",
+                dtype="text",
+                value="hertz",
+                doc="Unit of measurement.",
+            ),
+        ],
+    )
+
+    # Note: PeakToTroughSeconds and TroughHalfWidthSeconds were considered as
+    # canonical cell-intrinsic typed columns but deferred to follow-up PRs.
+    # Each has cross-pipeline variability axes (peak_sign convention,
+    # upsampling factor, channel selection, "half of what" definition) that
+    # warrant their own discussion. They still round-trip as plain VectorData
+    # columns on nwbfile.units; only FiringRate gets typed-column status in
+    # v1 as the illustrative case.
+
+    # Run-dependent: live on MetricsRun instances
+
+    # Note: Snr (signal-to-noise ratio) was considered as a canonical run-dependent
+    # column but deferred. Pipelines disagree on the formula along three axes
+    # (signal_estimator, noise_estimator, channel_selection), and a single
+    # canonical definition would either favor one convention over the others or
+    # require so many attributes that the column becomes awkward. Until the field
+    # converges or a hybrid attribute design proves itself, SNR values still
+    # round-trip as an untyped float column named "snr" on MetricsRun instances.
+
+    # Note: PresenceRatio, IsiViolationsRatio, AmplitudeCutoff were considered as
+    # canonical run-dependent typed columns but deferred. Sub-agent research
+    # (see canonical_unit_columns.md in the vault) found that each requires 2-4
+    # attributes to capture cross-pipeline variability cleanly:
+    #   - PresenceRatio: bin_sizing_convention, mean_fr_ratio_thresh, analysis_window
+    #   - IsiViolationsRatio: refractory_period_ms, censored_period_ms, formula enum
+    #   - AmplitudeCutoff: num_histogram_bins, histogram_smoothing_value,
+    #     amplitudes_bins_min_ratio, method enum
+    # Until the field converges on canonical conventions or until we are
+    # confident enough in a heavier attribute design, these metrics round-trip
+    # as plain (untyped) VectorData columns inside MetricsRun instances. The
+    # column name is preserved (so SI reconstruction works) but no schema-level
+    # type tag is committed.
+
+    # Note: AmplitudeMedian was considered as a canonical cell-intrinsic typed
+    # column but deferred. Cross-pipeline values differ by factors of 2-3
+    # because of orthogonal extraction-method, central-tendency, and
+    # sign-convention disagreements (SI signed-sample-median vs Allen
+    # mean-peak-to-peak vs IBL geometric-median-in-dB). Round-trips as a plain
+    # VectorData column on nwbfile.units.
+
+    # ------------------------------------------------------------------
+    # MetricsRun: multi-instance container for run-dependent metrics
+    # ------------------------------------------------------------------
+    metrics_run = NWBGroupSpec(
+        neurodata_type_def="MetricsRun",
+        neurodata_type_inc="DynamicTable",
+        default_name="metrics_run",
+        doc=(
+            "One analysis run's worth of per-unit run-dependent metrics. Each row "
+            "is one unit; columns are run-dependent metric values stored as "
+            "plain VectorData (no canonical types committed in v1). "
+            "Multiple MetricsRun instances coexist under SpikeSortingExtensions for "
+            "multiple curation runs (default run, valid-window-restricted run, "
+            "per-period drift QC runs). The instance name carries the run identity "
+            "(e.g., 'quality_metrics_default', 'quality_metrics_valid_windows')."
         ),
         datasets=[
             NWBDatasetSpec(
                 name="unit",
                 neurodata_type_inc="DynamicTableRegion",
                 doc=(
-                    "Reference to the units table for each row, identifying which unit "
-                    "each valid period belongs to."
+                    "Reference to the row in nwbfile.units that each row of this "
+                    "MetricsRun describes. Makes row-to-unit alignment explicit."
                 ),
+            ),
+            NWBDatasetSpec(
+                name="valid_intervals",
+                neurodata_type_inc="VectorData",
+                dtype="float",
+                dims=["num_intervals", "start|end"],
+                shape=[None, 2],
+                quantity="?",
+                doc=(
+                    "Per-unit observation intervals (start, stop) pairs in seconds, "
+                    "describing the time windows over which metrics in this run were "
+                    "computed. If absent, the metrics were computed over the whole "
+                    "recording."
+                ),
+            ),
+            NWBDatasetSpec(
+                name="valid_intervals_index",
+                neurodata_type_inc="VectorIndex",
+                quantity="?",
+                doc="Index into valid_intervals for each row, grouping intervals by row.",
             ),
         ],
     )
@@ -649,9 +750,12 @@ def main():
                 doc="Concatenated-channels PCA projections of spikes (single-ragged).",
             ),
             NWBGroupSpec(
-                neurodata_type_inc="ValidUnitPeriods",
-                quantity="?",
-                doc="Valid unit periods extension data.",
+                neurodata_type_inc="MetricsRun",
+                quantity="*",
+                doc=(
+                    "Run-dependent per-unit metrics, one instance per analysis run. "
+                    "Multiple instances coexist for different curation runs."
+                ),
             ),
         ],
     )
@@ -736,7 +840,15 @@ def main():
         amplitude_scalings,
         pca_projections_by_channel,
         pca_projections_concatenated,
-        valid_unit_periods,
+        # Canonical typed VectorData columns (cell-intrinsic, live on nwbfile.units)
+        firing_rate,
+        # No canonical typed VectorData columns are committed for the
+        # run-dependent side in v1. Run-dependent metrics still flow into
+        # MetricsRun instances as plain VectorData columns; the field has
+        # not converged on canonical conventions yet (see vault note
+        # canonical_unit_columns.md). Add typed columns here in v2.
+        # Multi-instance container for run-dependent metrics
+        metrics_run,
         spike_sorting_extensions,
         spike_sorting_container,
     ]

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -557,7 +557,7 @@ def main():
     # Canonical typed VectorData column classes
     # ------------------------------------------------------------------
     # These are stand-alone VectorData subtypes that the writer adds to either
-    # nwbfile.units (cell-intrinsic properties) or MetricsRun instances
+    # nwbfile.units (cell-intrinsic properties) or UnitMetrics instances
     # (run-dependent properties). The split is by what the value is, not by what
     # it is used for: cell-intrinsic values estimate biological properties and
     # are stable across reasonable analyses; run-dependent values describe the
@@ -587,57 +587,26 @@ def main():
         ],
     )
 
-    # Note: PeakToTroughSeconds and TroughHalfWidthSeconds were considered as
-    # canonical cell-intrinsic typed columns but deferred to follow-up PRs.
-    # Each has cross-pipeline variability axes (peak_sign convention,
-    # upsampling factor, channel selection, "half of what" definition) that
-    # warrant their own discussion. They still round-trip as plain VectorData
-    # columns on nwbfile.units; only FiringRate gets typed-column status in
-    # v1 as the illustrative case.
-
-    # Run-dependent: live on MetricsRun instances
-
-    # Note: Snr (signal-to-noise ratio) was considered as a canonical run-dependent
-    # column but deferred. Pipelines disagree on the formula along three axes
-    # (signal_estimator, noise_estimator, channel_selection), and a single
-    # canonical definition would either favor one convention over the others or
-    # require so many attributes that the column becomes awkward. Until the field
-    # converges or a hybrid attribute design proves itself, SNR values still
-    # round-trip as an untyped float column named "snr" on MetricsRun instances.
-
-    # Note: PresenceRatio, IsiViolationsRatio, AmplitudeCutoff were considered as
-    # canonical run-dependent typed columns but deferred. Sub-agent research
-    # (see canonical_unit_columns.md in the vault) found that each requires 2-4
-    # attributes to capture cross-pipeline variability cleanly:
-    #   - PresenceRatio: bin_sizing_convention, mean_fr_ratio_thresh, analysis_window
-    #   - IsiViolationsRatio: refractory_period_ms, censored_period_ms, formula enum
-    #   - AmplitudeCutoff: num_histogram_bins, histogram_smoothing_value,
-    #     amplitudes_bins_min_ratio, method enum
-    # Until the field converges on canonical conventions or until we are
-    # confident enough in a heavier attribute design, these metrics round-trip
-    # as plain (untyped) VectorData columns inside MetricsRun instances. The
-    # column name is preserved (so SI reconstruction works) but no schema-level
-    # type tag is committed.
-
-    # Note: AmplitudeMedian was considered as a canonical cell-intrinsic typed
-    # column but deferred. Cross-pipeline values differ by factors of 2-3
-    # because of orthogonal extraction-method, central-tendency, and
-    # sign-convention disagreements (SI signed-sample-median vs Allen
-    # mean-peak-to-peak vs IBL geometric-median-in-dB). Round-trips as a plain
-    # VectorData column on nwbfile.units.
+    # Other canonical column candidates (PeakToTroughSeconds, TroughHalfWidthSeconds,
+    # AmplitudeMedian on the cell-intrinsic side; Snr, PresenceRatio,
+    # IsiViolationsRatio, AmplitudeCutoff on the run-dependent side) were considered
+    # for v1 and deferred to follow-up PRs after cross-pipeline variability research.
+    # They still round-trip as plain VectorData columns on the appropriate table
+    # (nwbfile.units or UnitMetrics instances), just without typed-column tags.
+    # Background: see `canonical_unit_columns.md` in the project vault.
 
     # ------------------------------------------------------------------
-    # MetricsRun: multi-instance container for run-dependent metrics
+    # UnitMetrics: multi-instance container for run-dependent metrics
     # ------------------------------------------------------------------
-    metrics_run = NWBGroupSpec(
-        neurodata_type_def="MetricsRun",
+    unit_metrics = NWBGroupSpec(
+        neurodata_type_def="UnitMetrics",
         neurodata_type_inc="DynamicTable",
-        default_name="metrics_run",
+        default_name="unit_metrics",
         doc=(
             "One analysis run's worth of per-unit run-dependent metrics. Each row "
             "is one unit; columns are run-dependent metric values stored as "
             "plain VectorData (no canonical types committed in v1). "
-            "Multiple MetricsRun instances coexist under SpikeSortingExtensions for "
+            "Multiple UnitMetrics instances coexist under SpikeSortingExtensions for "
             "multiple curation runs (default run, valid-window-restricted run, "
             "per-period drift QC runs). The instance name carries the run identity "
             "(e.g., 'quality_metrics_default', 'quality_metrics_valid_windows')."
@@ -648,7 +617,7 @@ def main():
                 neurodata_type_inc="DynamicTableRegion",
                 doc=(
                     "Reference to the row in nwbfile.units that each row of this "
-                    "MetricsRun describes. Makes row-to-unit alignment explicit."
+                    "UnitMetrics describes. Makes row-to-unit alignment explicit."
                 ),
             ),
             NWBDatasetSpec(
@@ -750,7 +719,7 @@ def main():
                 doc="Concatenated-channels PCA projections of spikes (single-ragged).",
             ),
             NWBGroupSpec(
-                neurodata_type_inc="MetricsRun",
+                neurodata_type_inc="UnitMetrics",
                 quantity="*",
                 doc=(
                     "Run-dependent per-unit metrics, one instance per analysis run. "
@@ -844,11 +813,11 @@ def main():
         firing_rate,
         # No canonical typed VectorData columns are committed for the
         # run-dependent side in v1. Run-dependent metrics still flow into
-        # MetricsRun instances as plain VectorData columns; the field has
+        # UnitMetrics instances as plain VectorData columns; the field has
         # not converged on canonical conventions yet (see vault note
         # canonical_unit_columns.md). Add typed columns here in v2.
         # Multi-instance container for run-dependent metrics
-        metrics_run,
+        unit_metrics,
         spike_sorting_extensions,
         spike_sorting_container,
     ]


### PR DESCRIPTION
I'd like to propose a different shape for spike-sorting metrics storage than the open MetricExtension PR (#18). Two pieces:

**Cell properties as typed columns on the Units table**
Some cell properties are properties of the cell, independent of any analysis run, so they belong on `nwbfile.units` as typed VectorData columns. As a minimal implementation of the idea I am adding `FiringRate`; other candidates are peak-to-trough duration, trough half-width, and median amplitude, we can add them after this PR if we refine this idea.

**A generic UnitMetrics table for run-dependent metrics**
Besides cell properties, the metrics extension covers a lot. From the SpikeInterface side we have `quality_metrics` (defined by purpose), `template_metrics` (defined by source), and `spiketrain_metrics` (defined by source). Like in #18, I have a generic DynamicTable to cover all those cases, but with some differences from #18: (1) explicit linkage to the Units table via a required `unit` DynamicTableRegion per row, which ensures provenance; (2) per-row `obs_intervals` matching the NWB-core `Units.obs_intervals` ragged-column pattern, so we reuse the existing NWB convention for period attribution rather than introducing a new shape (this also covers the periods produced by SpikeInterface's `valid_unit_periods` extension).

Taken together, this PR is the structural base: typed canonical columns on `nwbfile.units` for cell properties, plus a generic `UnitMetrics` DynamicTable for run-dependent metrics. Future PRs can either canonize more typed columns on `Units` or subclass `UnitMetrics` for specific purposes (e.g., curation) with their own canonical columns.