### PR TITLE
Add FiringRate and NumSpikes canonical typed VectorData columns

### DIFF
--- a/spec/ndx-spikesorting.extensions.yaml
+++ b/spec/ndx-spikesorting.extensions.yaml
@@ -10,6 +10,11 @@ datasets:
     dtype: text
     value: hertz
     doc: Unit of measurement.
+- neurodata_type_def: NumSpikes
+  neurodata_type_inc: VectorData
+  dtype: int64
+  doc: Total number of spikes of the unit. Cell-intrinsic property; written as a
+    column on nwbfile.units.
 - neurodata_type_def: UnitVectorData
   neurodata_type_inc: VectorData
   doc: A VectorData column carrying per-unit values. May reference the 

--- a/src/pynwb/ndx_spikesorting/__init__.py
+++ b/src/pynwb/ndx_spikesorting/__init__.py
@@ -28,8 +28,9 @@ AmplitudeScalings = get_class("AmplitudeScalings", "ndx-spikesorting")
 PCAProjectionsByChannel = get_class("PCAProjectionsByChannel", "ndx-spikesorting")
 PCAProjectionsConcatenated = get_class("PCAProjectionsConcatenated", "ndx-spikesorting")
 
-# Canonical typed VectorData column for nwbfile.units
+# Canonical typed VectorData columns for nwbfile.units
 FiringRate = get_class("FiringRate", "ndx-spikesorting")
+NumSpikes = get_class("NumSpikes", "ndx-spikesorting")
 
 # Typed VectorData carrying an optional time_support reference attribute
 UnitVectorData = get_class("UnitVectorData", "ndx-spikesorting")
@@ -80,6 +81,7 @@ __all__ = [
     "PCAProjectionsByChannel",
     "PCAProjectionsConcatenated",
     "FiringRate",
+    "NumSpikes",
     "UnitVectorData",
     "UnitsMetrics",
     "ValidUnitPeriods",

--- a/src/pynwb/ndx_spikesorting/utils.py
+++ b/src/pynwb/ndx_spikesorting/utils.py
@@ -29,6 +29,7 @@ from ndx_spikesorting import (
     PCAProjectionsByChannel,
     PCAProjectionsConcatenated,
     FiringRate,
+    NumSpikes,
     UnitVectorData,
     UnitsMetrics,
     ValidUnitPeriods,
@@ -53,11 +54,12 @@ def find_extension_metric_targets(col_name: str) -> tuple[str, ...]:
 
 # Registries mapping canonical metric names to typed VectorData classes.
 # The writer uses col_cls=<class> when adding a column whose class appears here;
-# other columns are written as plain VectorData with the name preserved. 
-# The registries are the single point of SpikeInterface-specific knowledge in the loader; 
+# other columns are written as plain VectorData with the name preserved.
+# The registries are the single point of SpikeInterface-specific knowledge in the loader;
 # the spec stays tool-agnostic.
 UNITS_TYPED_COLUMNS = {
-    "firing_rate": FiringRate
+    "firing_rate": FiringRate,
+    "num_spikes": NumSpikes,
 }
 
 

--- a/src/pynwb/tests/conftest.py
+++ b/src/pynwb/tests/conftest.py
@@ -1,0 +1,66 @@
+"""Shared pytest fixtures for the ndx-spikesorting test suite.
+
+These fixtures are pytest-only; ``TestCase`` tests in ``test_spikesorting.py``
+keep their local module-level helpers until they migrate to pytest.
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def sorting_analyzer_with_extensions():
+    """SortingAnalyzer with all standard SI extensions and metrics computed.
+
+    Module-scoped so the compute step runs once per test file rather than per
+    test. Tests should not mutate the returned objects. Add new SI extensions
+    here as future canonization PRs need them (template_metrics, etc.).
+    """
+    from spikeinterface.core import create_sorting_analyzer, generate_ground_truth_recording
+
+    recording, sorting = generate_ground_truth_recording(
+        durations=[5.0],
+        num_units=5,
+        num_channels=10,
+        seed=42,
+    )
+    sa = create_sorting_analyzer(
+        sorting=sorting,
+        recording=recording,
+        format="memory",
+        sparse=True,
+    )
+    sa.compute(
+        {
+            "random_spikes": {"max_spikes_per_unit": 10, "seed": 42},
+            "waveforms": {},
+            "templates": {},
+            "noise_levels": {},
+            "spike_amplitudes": {},
+            "quality_metrics": {"metric_names": ["firing_rate", "num_spikes"]},
+        }
+    )
+    return sa, recording, sorting
+
+
+@pytest.fixture
+def nwbfile_with_recording_and_sorting(sorting_analyzer_with_extensions):
+    """Fresh NWBFile populated with the module-scoped recording + sorting.
+
+    Function-scoped — each test gets its own NWBFile so writes don't leak
+    across tests, while the underlying recording/sorting/analyzer are shared.
+    """
+    from datetime import datetime, timezone
+
+    from neuroconv.tools.spikeinterface import add_recording_to_nwbfile, add_sorting_to_nwbfile
+    from pynwb import NWBFile
+
+    _, recording, sorting = sorting_analyzer_with_extensions
+
+    nwbfile = NWBFile(
+        session_description="Test",
+        identifier=f"test_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
+        session_start_time=datetime.now(timezone.utc),
+    )
+    add_recording_to_nwbfile(recording, nwbfile=nwbfile, write_as="raw", iterator_type=None)
+    add_sorting_to_nwbfile(sorting, nwbfile=nwbfile, write_as="units")
+    return nwbfile

--- a/src/pynwb/tests/test_canonical_columns_classes.py
+++ b/src/pynwb/tests/test_canonical_columns_classes.py
@@ -1,0 +1,95 @@
+"""Class-level tests for canonical typed VectorData column types.
+
+One ``Test<ClassName>`` per canonical type. Tests are independent of the
+SortingAnalyzer pipeline.
+"""
+
+import numpy as np
+import pytest
+
+from pynwb import NWBHDF5IO, read_nwb
+from pynwb.testing.mock.ecephys import mock_Units
+from pynwb.testing.mock.file import mock_NWBFile
+
+from ndx_spikesorting import FiringRate, NumSpikes
+
+
+@pytest.fixture
+def nwbfile_with_units():
+    """NWBFile with a populated Units table from pynwb's mocks."""
+    nwbfile = mock_NWBFile()
+    mock_Units(num_units=3, nwbfile=nwbfile)
+    return nwbfile
+
+
+class TestFiringRate:
+    def test_construct(self):
+        fr = FiringRate(name="firing_rate", description="rates", data=[1.0, 2.0, 3.0])
+        assert fr.name == "firing_rate"
+        np.testing.assert_array_equal(fr.data, [1.0, 2.0, 3.0])
+
+    def test_unit_attribute(self):
+        fr = FiringRate(name="firing_rate", description="rates", data=[1.0])
+        assert fr.unit == "hertz"
+
+    def test_added_to_units_table(self, nwbfile_with_units):
+        nwbfile_with_units.units.add_column(
+            name="firing_rate",
+            description="rates",
+            data=[10.0, 20.0, 30.0],
+            col_cls=FiringRate,
+        )
+        assert isinstance(nwbfile_with_units.units["firing_rate"], FiringRate)
+
+    def test_round_trip_through_nwb_io(self, nwbfile_with_units, tmp_path):
+        nwbfile_with_units.units.add_column(
+            name="firing_rate",
+            description="rates",
+            data=[10.0, 20.0, 30.0],
+            col_cls=FiringRate,
+        )
+
+        path = tmp_path / "firing_rate.nwb"
+        with NWBHDF5IO(path, mode="w") as io:
+            io.write(nwbfile_with_units)
+
+        loaded = read_nwb(path=path)
+        assert isinstance(loaded.units["firing_rate"], FiringRate)
+        np.testing.assert_array_equal(loaded.units["firing_rate"].data[:], [10.0, 20.0, 30.0])
+        assert loaded.units["firing_rate"].unit == "hertz"
+
+
+class TestNumSpikes:
+    def test_construct(self):
+        ns = NumSpikes(
+            name="num_spikes",
+            description="counts",
+            data=np.array([10, 20, 30], dtype=np.int64),
+        )
+        assert ns.name == "num_spikes"
+        np.testing.assert_array_equal(ns.data, [10, 20, 30])
+
+    def test_added_to_units_table(self, nwbfile_with_units):
+        nwbfile_with_units.units.add_column(
+            name="num_spikes",
+            description="counts",
+            data=np.array([10, 20, 30], dtype=np.int64),
+            col_cls=NumSpikes,
+        )
+        assert isinstance(nwbfile_with_units.units["num_spikes"], NumSpikes)
+
+    def test_round_trip_through_nwb_io(self, nwbfile_with_units, tmp_path):
+        nwbfile_with_units.units.add_column(
+            name="num_spikes",
+            description="counts",
+            data=np.array([10, 20, 30], dtype=np.int64),
+            col_cls=NumSpikes,
+        )
+
+        path = tmp_path / "num_spikes.nwb"
+        with NWBHDF5IO(path, mode="w") as io:
+            io.write(nwbfile_with_units)
+
+        loaded = read_nwb(path=path)
+        assert isinstance(loaded.units["num_spikes"], NumSpikes)
+        np.testing.assert_array_equal(loaded.units["num_spikes"].data[:], [10, 20, 30])

--- a/src/pynwb/tests/test_metrics_and_cell_properties_columns.py
+++ b/src/pynwb/tests/test_metrics_and_cell_properties_columns.py
@@ -1,0 +1,90 @@
+"""Round-trip tests for canonical typed VectorData columns on nwbfile.units.
+
+Cell-intrinsic typed columns (FiringRate, NumSpikes, ...) live on
+``nwbfile.units`` rather than inside the SpikeSortingExtensions container.
+This module exercises their writer + reader paths and the SpikeInterface
+extension-aliasing policy committed by ``UNITS_TYPED_COLUMNS``.
+"""
+
+import numpy as np
+
+from pynwb import NWBHDF5IO
+
+from ndx_spikesorting import (
+    FiringRate,
+    NumSpikes,
+    add_sorting_analyzer_to_nwbfile,
+    read_sorting_analyzer_from_nwb,
+)
+
+
+def test_firing_rate_column_is_typed(sorting_analyzer_with_extensions, nwbfile_with_recording_and_sorting):
+    """firing_rate column on nwbfile.units is a FiringRate instance."""
+    sa, _, _ = sorting_analyzer_with_extensions
+    add_sorting_analyzer_to_nwbfile(sa, nwbfile_with_recording_and_sorting)
+
+    assert "firing_rate" in nwbfile_with_recording_and_sorting.units.colnames
+    assert isinstance(nwbfile_with_recording_and_sorting.units["firing_rate"], FiringRate)
+
+
+def test_num_spikes_column_is_typed(sorting_analyzer_with_extensions, nwbfile_with_recording_and_sorting):
+    """num_spikes column on nwbfile.units is a NumSpikes instance."""
+    sa, _, _ = sorting_analyzer_with_extensions
+    add_sorting_analyzer_to_nwbfile(sa, nwbfile_with_recording_and_sorting)
+
+    assert "num_spikes" in nwbfile_with_recording_and_sorting.units.colnames
+    assert isinstance(nwbfile_with_recording_and_sorting.units["num_spikes"], NumSpikes)
+
+
+def test_values_match_source(sorting_analyzer_with_extensions, nwbfile_with_recording_and_sorting):
+    """Typed columns carry the values from the SI extension."""
+    sa, _, _ = sorting_analyzer_with_extensions
+    add_sorting_analyzer_to_nwbfile(sa, nwbfile_with_recording_and_sorting)
+
+    df = sa.get_extension("quality_metrics").get_data()
+
+    np.testing.assert_array_almost_equal(
+        np.asarray(nwbfile_with_recording_and_sorting.units["firing_rate"].data[:]),
+        df["firing_rate"].to_numpy(),
+        decimal=5,
+    )
+    np.testing.assert_array_equal(
+        np.asarray(nwbfile_with_recording_and_sorting.units["num_spikes"].data[:]),
+        df["num_spikes"].to_numpy(),
+    )
+
+
+def test_round_trip_to_metric_extensions(
+    sorting_analyzer_with_extensions, nwbfile_with_recording_and_sorting, tmp_path
+):
+    """After write/read, typed columns reconstruct their SI metric extensions.
+
+    ``firing_rate`` and ``num_spikes`` are produced by both ``quality_metrics``
+    and ``spiketrain_metrics``, so on read they are routed back into every SI
+    extension that defines them (route-to-both, via
+    ``find_extension_metric_targets``).
+    """
+    sa, _, _ = sorting_analyzer_with_extensions
+    add_sorting_analyzer_to_nwbfile(sa, nwbfile_with_recording_and_sorting)
+
+    path = tmp_path / "test_cell_intrinsic_columns.nwb"
+    with NWBHDF5IO(path, mode="w") as io:
+        io.write(nwbfile_with_recording_and_sorting)
+
+    sa_restored = read_sorting_analyzer_from_nwb(path)
+
+    original_df = sa.get_extension("quality_metrics").get_data()
+    for ext_name in ("quality_metrics", "spiketrain_metrics"):
+        assert ext_name in sa_restored.extensions
+        df = sa_restored.get_extension(ext_name).get_data()
+        assert "firing_rate" in df.columns
+        assert "num_spikes" in df.columns
+        np.testing.assert_array_almost_equal(
+            df["firing_rate"].to_numpy(),
+            original_df["firing_rate"].to_numpy(),
+            decimal=5,
+        )
+        np.testing.assert_array_equal(
+            df["num_spikes"].to_numpy(),
+            original_df["num_spikes"].to_numpy(),
+        )

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -585,6 +585,16 @@ def main():
         ],
     )
 
+    num_spikes = NWBDatasetSpec(
+        neurodata_type_def="NumSpikes",
+        neurodata_type_inc="VectorData",
+        dtype="int64",
+        doc=(
+            "Total number of spikes of the unit. Cell-intrinsic property; "
+            "written as a column on nwbfile.units."
+        ),
+    )
+
     unit_vector_data = NWBDatasetSpec(
         neurodata_type_def="UnitVectorData",
         neurodata_type_inc="VectorData",
@@ -845,6 +855,7 @@ def main():
         pca_projections_by_channel,
         pca_projections_concatenated,
         firing_rate,
+        num_spikes,
         valid_unit_periods,
         unit_vector_data,
         units_metrics,


### PR DESCRIPTION
This PR adds two canonical columns in the sense of #21: `FiringRate` and `NumSpikes`. I am adding the types and including them in the pipeline from writing sorting-analyzer to NWB and back.

For round-trip from NWB back to sorting-analyzer there is a design decision here. Reading back from a units table always lands in the `spiketrain_metrics` extension (instead of the `quality_metrics` one). I think this makes more sense (these are properties of the spike train) and I also feel this is aligned with [SpikeInterface PR #4183](https://github.com/SpikeInterface/spikeinterface/pull/4183).

Note there is some overlap with #20 but I think that's fine.